### PR TITLE
ci: bump Docker GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for tags
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Determine image tag
         id: determine_tag
@@ -120,14 +120,14 @@ jobs:
 
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## Summary

Bump Docker-related GitHub Actions to versions that support Node.js 24, ahead of the **June 2, 2026** forced migration.

## Changes

| Action | Old | New |
|--------|-----|-----|
| `docker/setup-buildx-action` | `@v3` | `@v4` |
| `docker/login-action` | `@v3` | `@v4` |
| `docker/build-push-action` | `@v5` | `@v6` |

## Reference

- [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

Closes #10