### PR TITLE
ci: opt into Node.js 24 for all GitHub Actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -7,6 +7,9 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-test:
     name: Build and Test Package


### PR DESCRIPTION
## Summary

Follow-up to the Docker action version bumps. The remaining Node.js 20 warnings come from `actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4`, and `docker/build-push-action@v6` — all already at their latest major version but requiring an explicit Node.js 24 opt-in.

Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the top-level workflow env to silence all remaining warnings and ensure compatibility before the June 2, 2026 forced migration.

## Changes

```yaml
env:
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
```

## Reference

- [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

Closes #10