### PR TITLE
feat: add FinlightDataListener (FDL) component (#15)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,41 @@ Documentation
 For architecture details, component descriptions, and API reference, see the
 `full documentation on Read the Docs <https://kuhl-haus-mdp.readthedocs.io/en/latest/>`_.
 
+Configuration
+-------------
+
+Finlight Data Listener (FDL)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``FinlightDataListener`` component reads the following environment variables
+when constructing configuration at the application layer:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Variable
+     - Required
+     - Description
+   * - ``FINLIGHT_API_KEY``
+     - Yes
+     - Finlight API key for authenticating WebSocket connections
+   * - ``FINLIGHT_QUERY``
+     - No
+     - Boolean search query for filtering articles (e.g. ``"earnings AND revenue"``)
+   * - ``FINLIGHT_TICKERS``
+     - No
+     - Comma-separated list of ticker symbols to filter (e.g. ``"AAPL,MSFT,GOOG"``)
+   * - ``FINLIGHT_SOURCES``
+     - No
+     - Comma-separated list of news source domains (e.g. ``"reuters.com,bloomberg.com"``)
+   * - ``FINLIGHT_LANGUAGE``
+     - No
+     - ISO 639-1 language code for filtering articles (e.g. ``"en"``)
+   * - ``FINLIGHT_RAW``
+     - No
+     - Set to ``"true"`` to use the raw WebSocket stream (no AI enrichment; faster delivery)
+
 Additional Resources
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "aiohttp",
     "aio-pika",
     "fastapi",
+    "finlight-client",
     "massive",
     "opentelemetry-api",
     "opentelemetry-sdk",

--- a/src/kuhl_haus/mdp/components/finlight_data_listener.py
+++ b/src/kuhl_haus/mdp/components/finlight_data_listener.py
@@ -1,0 +1,237 @@
+"""WebSocket client wrapper for Finlight financial news streams.
+
+Manages a persistent WebSocket connection to the Finlight news API, handles
+reconnection logic on disconnect, and delegates incoming articles to a user-
+provided handler. Designed to run as a long-lived background task that survives
+temporary connection failures.
+"""
+import asyncio
+import logging
+from typing import Awaitable, Callable, List, Optional, Union
+
+from finlight_client import ApiConfig, FinlightApi
+from finlight_client.models import (
+    GetArticlesWebSocketParams,
+    GetRawArticlesWebSocketParams,
+)
+
+
+class FinlightDataListener:
+    """Maintain Finlight WebSocket connection with auto-reconnect logic.
+
+    Wraps the official Finlight SDK FinlightApi, providing lifecycle management
+    (start/stop/restart), connection health tracking, and automatic reconnection.
+    When the WebSocket disconnects, automatically attempts to reconnect. Delegates
+    each incoming article to the provided message_handler callable.
+
+    Threading: Spawns async task for ws_connection WebSocket connect(); caller is
+    responsible for awaiting or managing the task lifecycle.
+    """
+
+    connection_status: dict
+    ws_connection: Union[FinlightApi, None]
+    ws_coroutine: Union[asyncio.Task, None]
+    _query: Optional[str]
+    _tickers: Optional[List[str]]
+    _sources: Optional[List[str]]
+    _language: Optional[str]
+    raw: bool
+    max_reconnects: Optional[int]
+
+    @property
+    def query(self) -> Optional[str]:
+        """Current WebSocket article query filter."""
+        return self._query
+
+    @query.setter
+    def query(self, value: Optional[str]):
+        self._query = value
+        self.connection_status["query"] = value
+        if self.connection_status.get("connected"):
+            asyncio.create_task(self.restart())
+
+    @property
+    def tickers(self) -> Optional[List[str]]:
+        """Current WebSocket ticker filter."""
+        return self._tickers
+
+    @tickers.setter
+    def tickers(self, value: Optional[List[str]]):
+        self._tickers = value
+        self.connection_status["tickers"] = value
+        if self.connection_status.get("connected"):
+            asyncio.create_task(self.restart())
+
+    @property
+    def sources(self) -> Optional[List[str]]:
+        """Current WebSocket news source filter."""
+        return self._sources
+
+    @sources.setter
+    def sources(self, value: Optional[List[str]]):
+        self._sources = value
+        self.connection_status["sources"] = value
+        if self.connection_status.get("connected"):
+            asyncio.create_task(self.restart())
+
+    @property
+    def language(self) -> Optional[str]:
+        """Current WebSocket language filter."""
+        return self._language
+
+    @language.setter
+    def language(self, value: Optional[str]):
+        self._language = value
+        self.connection_status["language"] = value
+        if self.connection_status.get("connected"):
+            asyncio.create_task(self.restart())
+
+    def __init__(
+        self,
+        api_key: str,
+        message_handler: Union[
+            Callable[..., Awaitable],
+            Callable,
+        ],
+        query: Optional[str] = None,
+        tickers: Optional[List[str]] = None,
+        sources: Optional[List[str]] = None,
+        language: Optional[str] = None,
+        raw: bool = False,
+        max_reconnects: Optional[int] = 5,
+        **kwargs,
+    ):
+        self.logger = logging.getLogger(__name__)
+        self.api_key = api_key
+        self.message_handler = message_handler
+        self._query = query
+        self._tickers = tickers
+        self._sources = sources
+        self._language = language
+        self.raw = raw
+        self.max_reconnects = max_reconnects
+        self.kwargs = kwargs
+        self.connection_status = {
+            "connected": False,
+            "healthy": False,
+            "language": self.language,
+            "query": self.query,
+            "reconnects": 0,
+            "sources": self.sources,
+            "tickers": self.tickers,
+        }
+
+    async def start(self):
+        """Instantiate FinlightApi client and spawn connection task.
+
+        Creates FinlightApi with configured API key, schedules async_task as a
+        background task. Does not block; caller must await the task or manage it
+        separately.
+
+        Side effects: Spawns asyncio.Task; updates connection_status dict.
+        """
+        try:
+            self.logger.info("Instantiating WebSocket client...")
+            self.ws_connection = FinlightApi(
+                config=ApiConfig(api_key=self.api_key),
+                **self.kwargs,
+            )
+            self.logger.info("Scheduling WebSocket client task...")
+            self.ws_coroutine = asyncio.create_task(self.async_task())
+        except Exception as e:
+            self.logger.error(f"Error starting WebSocket client: {e}")
+            await self.stop()
+
+    async def stop(self):
+        """Shutdown WebSocket connection gracefully.
+
+        Cancels coroutine task, stops the active WebSocket stream, and resets
+        connection status. Waits 1s between steps to allow in-flight messages
+        to flush.
+
+        Side effects: Closes network socket; updates connection_status dict.
+        """
+        try:
+            self.logger.info("Shutting down WebSocket client...")
+            self.ws_coroutine.cancel()
+            await asyncio.sleep(1)
+            self.logger.info("stopping WebSocket stream...")
+            if self.raw:
+                self.ws_connection.raw_websocket.stop()
+            else:
+                self.ws_connection.websocket.stop()
+            self.logger.info("done.")
+        except Exception as e:
+            self.logger.error(f"Error stopping WebSocket client: {e}")
+        self.connection_status["connected"] = False
+        self.ws_connection = None
+        self.ws_coroutine = None
+
+    async def restart(self):
+        """Cycle connection: stop, wait 1s, start."""
+        try:
+            self.logger.info("Stopping WebSocket client...")
+            await self.stop()
+            self.logger.info("done")
+            await asyncio.sleep(1)
+            self.logger.info("Starting WebSocket client...")
+            await self.start()
+            self.logger.info("done")
+        except Exception as e:
+            self.logger.error(f"Error restarting WebSocket client: {e}")
+
+    async def async_task(self):
+        """Connect to Finlight WebSocket and handle disconnections.
+
+        Calls ws_connection websocket connect() with message_handler and awaits
+        it. On disconnect, reconnects immediately and increments the reconnect
+        counter for observability.
+
+        Side effects: Network I/O (WebSocket); calls message_handler for each
+        incoming article.
+        """
+        try:
+            self.logger.info("Connecting to Finlight news stream...")
+            self.connection_status["connected"] = True
+            self.connection_status["healthy"] = True
+
+            if self.raw:
+                request_params = GetRawArticlesWebSocketParams(
+                    query=self.query,
+                    sources=self.sources,
+                    language=self.language,
+                )
+                connect_coro = self.ws_connection.raw_websocket.connect(
+                    request_payload=request_params,
+                    on_article=self.message_handler,
+                )
+            else:
+                request_params = GetArticlesWebSocketParams(
+                    query=self.query,
+                    tickers=self.tickers,
+                    sources=self.sources,
+                    language=self.language,
+                )
+                connect_coro = self.ws_connection.websocket.connect(
+                    request_payload=request_params,
+                    on_article=self.message_handler,
+                )
+
+            await asyncio.gather(connect_coro, return_exceptions=True)
+
+            self.connection_status["connected"] = False
+            self.logger.info("Disconnected from Finlight news stream...")
+            self.connection_status["healthy"] = False
+            self.connection_status["reconnects"] += 1
+            self.logger.info(
+                f"Reconnection attempt "
+                f"{self.connection_status['reconnects']}..."
+            )
+            await self.start()
+        except Exception as e:
+            self.logger.error(
+                f"Unhandled exception thrown: {e}",
+                exc_info=True,
+                stack_info=True,
+            )
+            await self.stop()

--- a/tests/components/test_finlight_data_listener.py
+++ b/tests/components/test_finlight_data_listener.py
@@ -1,0 +1,445 @@
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kuhl_haus.mdp.components.finlight_data_listener import FinlightDataListener
+
+
+@pytest.fixture
+def mock_message_handler():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_ws_client():
+    with patch(
+        "kuhl_haus.mdp.components.finlight_data_listener.FinlightApi"
+    ) as mock:
+        # Configure the instance to have async methods on websocket sub-client
+        instance = mock.return_value
+        instance.websocket.connect = AsyncMock()
+        instance.websocket.stop = MagicMock()
+        instance.raw_websocket.connect = AsyncMock()
+        instance.raw_websocket.stop = MagicMock()
+        yield mock
+
+
+@pytest.fixture
+def sut(mock_message_handler):
+    return FinlightDataListener(
+        api_key="test_api_key",
+        message_handler=mock_message_handler,
+        query="earnings",
+        tickers=["AAPL", "MSFT"],
+        sources=["reuters.com"],
+        language="en",
+        raw=False,
+        max_reconnects=3,
+        extra_param="extra_value",
+    )
+
+
+def test_fdl_init_with_valid_params_expect_correct_init(mock_message_handler):
+    # Arrange
+    api_key = "test_api_key"
+    query = "earnings"
+    tickers = ["AAPL"]
+    sources = ["reuters.com"]
+    language = "en"
+
+    # Act
+    sut = FinlightDataListener(
+        api_key=api_key,
+        message_handler=mock_message_handler,
+        query=query,
+        tickers=tickers,
+        sources=sources,
+        language=language,
+    )
+
+    # Assert
+    assert sut.api_key == api_key
+    assert sut.query == query
+    assert sut.tickers == tickers
+    assert sut.sources == sources
+    assert sut.language == language
+    assert sut.connection_status == {
+        "connected": False,
+        "healthy": False,
+        "language": language,
+        "query": query,
+        "reconnects": 0,
+        "sources": sources,
+        "tickers": tickers,
+    }
+
+
+@pytest.mark.asyncio
+async def test_fdl_start_with_valid_params_expect_ws_client_started(
+    sut, mock_ws_client
+):
+    # Arrange
+    with patch("asyncio.create_task") as mock_create_task:
+        # Act
+        await sut.start()
+
+        # Assert
+        mock_ws_client.assert_called_once()
+        call_kwargs = mock_ws_client.call_args.kwargs
+        assert call_kwargs["config"].api_key == sut.api_key
+        mock_create_task.assert_called_once()
+        assert sut.ws_connection == mock_ws_client.return_value
+        assert sut.ws_coroutine == mock_create_task.return_value
+
+
+@pytest.mark.asyncio
+async def test_fdl_start_with_exception_expect_error_logged_and_stopped(
+    sut, mock_ws_client
+):
+    # Arrange
+    mock_ws_client.side_effect = Exception("Test Error")
+    with patch.object(sut, "stop", new_callable=AsyncMock) as mock_stop:
+        # Act
+        await sut.start()
+
+        # Assert
+        mock_stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdl_stop_with_active_conn_expect_ws_client_stopped(
+    sut, mock_ws_client
+):
+    # Arrange
+    sut.ws_connection = mock_ws_client.return_value
+    mock_ws_coroutine = MagicMock(spec=asyncio.Task)
+    sut.ws_coroutine = mock_ws_coroutine
+    sut.connection_status["connected"] = True
+
+    # Act
+    # Save the connection because stop sets it to None
+    ws_connection = sut.ws_connection
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await sut.stop()
+
+        # Assert
+        mock_ws_coroutine.cancel.assert_called_once()
+        ws_connection.websocket.stop.assert_called_once()
+        ws_connection.raw_websocket.stop.assert_not_called()
+        assert sut.connection_status["connected"] is False
+        assert sut.ws_connection is None
+        assert sut.ws_coroutine is None
+
+
+@pytest.mark.asyncio
+async def test_fdl_stop_with_raw_mode_expect_raw_websocket_stopped(
+    mock_message_handler, mock_ws_client
+):
+    # Arrange
+    sut = FinlightDataListener(
+        api_key="test_api_key",
+        message_handler=mock_message_handler,
+        raw=True,
+    )
+    sut.ws_connection = mock_ws_client.return_value
+    mock_ws_coroutine = MagicMock(spec=asyncio.Task)
+    sut.ws_coroutine = mock_ws_coroutine
+    sut.connection_status["connected"] = True
+
+    # Act
+    ws_connection = sut.ws_connection
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await sut.stop()
+
+        # Assert — raw_websocket.stop() called, NOT websocket.stop()
+        mock_ws_coroutine.cancel.assert_called_once()
+        ws_connection.raw_websocket.stop.assert_called_once()
+        ws_connection.websocket.stop.assert_not_called()
+        assert sut.connection_status["connected"] is False
+        assert sut.ws_connection is None
+        assert sut.ws_coroutine is None
+
+
+@pytest.mark.asyncio
+async def test_fdl_restart_with_active_conn_expect_stop_and_start_called(sut):
+    # Arrange
+    with patch.object(sut, "stop", new_callable=AsyncMock) as mock_stop, \
+         patch.object(sut, "start", new_callable=AsyncMock) as mock_start, \
+         patch("asyncio.sleep", new_callable=AsyncMock):
+        # Act
+        await sut.restart()
+
+        # Assert
+        mock_stop.assert_awaited_once()
+        mock_start.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdl_stop_with_exception_expect_error_logged_and_state_reset(
+    sut, mock_ws_client, caplog
+):
+    # Arrange
+    sut.ws_connection = mock_ws_client.return_value
+    mock_ws_coroutine = MagicMock(spec=asyncio.Task)
+    mock_ws_coroutine.cancel.side_effect = Exception("Cancel Error")
+    sut.ws_coroutine = mock_ws_coroutine
+    sut.connection_status["connected"] = True
+
+    # Act
+    with caplog.at_level(logging.ERROR):
+        await sut.stop()
+
+    # Assert
+    assert sut.connection_status["connected"] is False
+    assert sut.ws_connection is None
+    assert sut.ws_coroutine is None
+    assert "Cancel Error" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fdl_restart_with_exception_expect_error_logged(sut, caplog):
+    # Arrange
+    with patch.object(
+        sut, "stop", new_callable=AsyncMock,
+        side_effect=Exception("Stop Error")
+    ) as mock_stop, caplog.at_level(logging.ERROR):
+        # Act
+        await sut.restart()
+
+        # Assert
+        mock_stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdl_query_changed_post_init_expect_connection_status_synced(sut):
+    # Arrange
+    original_query = sut.query
+    assert sut.connection_status["query"] == original_query
+
+    # Act
+    new_query = "dividends"
+    sut.query = new_query
+
+    # Assert
+    assert sut.query == new_query
+    assert sut.connection_status["query"] == sut.query
+    assert sut.connection_status["query"] == new_query
+
+
+@pytest.mark.asyncio
+async def test_fdl_tickers_changed_post_init_expect_connection_status_synced(sut):
+    # Arrange
+    original_tickers = sut.tickers
+    assert sut.connection_status["tickers"] is original_tickers
+
+    # Act
+    new_tickers = ["AAPL", "MSFT", "GOOG"]
+    sut.tickers = new_tickers
+
+    # Assert
+    assert sut.tickers is new_tickers
+    assert sut.connection_status["tickers"] is sut.tickers
+    assert sut.connection_status["tickers"] is new_tickers
+
+
+@pytest.mark.asyncio
+async def test_fdl_sources_changed_post_init_expect_connection_status_synced(sut):
+    # Arrange
+    original_sources = sut.sources
+    assert sut.connection_status["sources"] is original_sources
+
+    # Act
+    new_sources = ["reuters.com", "bloomberg.com"]
+    sut.sources = new_sources
+
+    # Assert
+    assert sut.sources is new_sources
+    assert sut.connection_status["sources"] is sut.sources
+    assert sut.connection_status["sources"] is new_sources
+
+
+@pytest.mark.asyncio
+async def test_fdl_language_changed_post_init_expect_connection_status_synced(sut):
+    # Arrange
+    original_language = sut.language
+    assert sut.connection_status["language"] == original_language
+
+    # Act
+    new_language = "de"
+    sut.language = new_language
+
+    # Assert
+    assert sut.language == new_language
+    assert sut.connection_status["language"] == sut.language
+    assert sut.connection_status["language"] == new_language
+
+
+@pytest.mark.asyncio
+async def test_fdl_language_changed_while_connected_expect_restart_called(sut):
+    # Arrange
+    sut.connection_status["connected"] = True
+    with patch.object(sut, "restart", new_callable=AsyncMock) as mock_restart, \
+         patch("asyncio.create_task") as mock_create_task:
+        mock_create_task.side_effect = lambda coro: coro  # capture but don't schedule
+
+        # Act
+        sut.language = "de"
+
+        # Assert
+        assert sut.language == "de"
+        assert sut.connection_status["language"] == "de"
+        mock_create_task.assert_called_once()  # restart was scheduled via create_task
+
+
+@pytest.mark.asyncio
+async def test_fdl_query_changed_while_connected_expect_restart_called(sut):
+    # Arrange
+    sut.connection_status["connected"] = True
+    with patch.object(sut, "restart", new_callable=AsyncMock) as mock_restart:
+        # Act
+        sut.query = "dividends"
+
+        # Assert
+        assert sut.query == "dividends"
+        assert sut.connection_status["query"] == "dividends"
+        mock_restart.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fdl_tickers_changed_while_connected_expect_restart_called(sut):
+    # Arrange
+    sut.connection_status["connected"] = True
+    with patch.object(sut, "restart", new_callable=AsyncMock) as mock_restart:
+        # Act
+        sut.tickers = ["TSLA"]
+
+        # Assert
+        assert sut.tickers == ["TSLA"]
+        assert sut.connection_status["tickers"] == ["TSLA"]
+        mock_restart.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fdl_sources_changed_while_connected_expect_restart_called(sut):
+    # Arrange
+    sut.connection_status["connected"] = True
+    new_sources = ["bloomberg.com"]
+    with patch.object(sut, "restart", new_callable=AsyncMock) as mock_restart:
+        # Act
+        sut.sources = new_sources
+
+        # Assert
+        assert sut.sources is new_sources
+        assert sut.connection_status["sources"] is new_sources
+        mock_restart.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fdl_rapid_property_changes_while_connected_expect_multiple_restarts(
+    sut,
+):
+    # Arrange — simulate rapid property changes during active connection
+    sut.connection_status["connected"] = True
+    created_tasks = []
+
+    with patch.object(sut, "restart", new_callable=AsyncMock) as mock_restart, \
+         patch("asyncio.create_task") as mock_create_task:
+        mock_create_task.side_effect = lambda coro: created_tasks.append(coro)
+
+        # Act — change query, tickers, sources in rapid succession
+        sut.query = "dividends"
+        sut.tickers = ["TSLA"]
+        sut.sources = ["bloomberg.com"]
+
+    # Assert — each property change scheduled a restart task
+    assert len(created_tasks) == 3
+    assert sut.query == "dividends"
+    assert sut.tickers == ["TSLA"]
+    assert sut.sources == ["bloomberg.com"]
+
+
+@pytest.mark.asyncio
+async def test_fdl_async_task_with_success_conn_expect_connected_and_healthy(
+    sut, mock_ws_client, mock_message_handler
+):
+    # Arrange
+    sut.ws_connection = mock_ws_client.return_value
+    # Prevent the reconnect call after gather
+    with patch("asyncio.gather", new_callable=AsyncMock) as mock_gather, \
+         patch.object(sut, "start", new_callable=AsyncMock):
+        # Act
+        await sut.async_task()
+
+        # Assert — connected and healthy set True on entry, then reset after gather
+        assert sut.connection_status["connected"] is False
+        assert sut.connection_status["healthy"] is False
+        mock_gather.assert_awaited_once()
+        args, kwargs = mock_gather.await_args
+        assert kwargs == {"return_exceptions": True}
+        # Verify first argument is a coroutine from connect call
+        assert asyncio.iscoroutine(args[0])
+        # Await it to avoid warnings and clean up
+        await args[0]
+
+
+@pytest.mark.asyncio
+async def test_fdl_async_task_with_recon_expect_recon_attempted(
+    sut, mock_ws_client
+):
+    # Arrange
+    sut.ws_connection = mock_ws_client.return_value
+
+    with patch("asyncio.gather", new_callable=AsyncMock) as mock_gather, \
+         patch.object(sut, "start", new_callable=AsyncMock) as mock_start:
+        # Act
+        await sut.async_task()
+
+        # Assert
+        mock_start.assert_awaited_once()
+        assert sut.connection_status["reconnects"] == 1
+        assert sut.connection_status["healthy"] is False
+        # Clean up awaited coroutines from gather
+        args, _ = mock_gather.await_args
+        await args[0]
+
+
+@pytest.mark.asyncio
+async def test_fdl_async_task_with_fatal_error_expect_stop_called(
+    sut, mock_ws_client
+):
+    # Arrange
+    sut.ws_connection = mock_ws_client.return_value
+    with patch("asyncio.gather", side_effect=Exception("Fatal Error")), \
+         patch.object(sut, "stop", new_callable=AsyncMock) as mock_stop:
+        # Act
+        await sut.async_task()
+
+        # Assert
+        mock_stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdl_async_task_with_raw_mode_expect_raw_websocket_used(
+    mock_message_handler, mock_ws_client
+):
+    # Arrange
+    sut = FinlightDataListener(
+        api_key="test_api_key",
+        message_handler=mock_message_handler,
+        raw=True,
+    )
+    sut.ws_connection = mock_ws_client.return_value
+
+    with patch("asyncio.gather", new_callable=AsyncMock) as mock_gather, \
+         patch.object(sut, "start", new_callable=AsyncMock):
+        # Act
+        await sut.async_task()
+
+        # Assert — raw_websocket.connect was called, not websocket.connect
+        args, kwargs = mock_gather.await_args
+        assert asyncio.iscoroutine(args[0])
+        mock_ws_client.return_value.raw_websocket.connect.assert_called_once()
+        mock_ws_client.return_value.websocket.connect.assert_not_called()
+        await args[0]


### PR DESCRIPTION
Closes #15

## Changes
- `src/kuhl_haus/mdp/components/finlight_data_listener.py` — `FinlightDataListener` class mirroring `MassiveDataListener`; constructor accepts `api_key` + `message_handler`; auto-reconnects on disconnect; supports filtered/raw WebSocket modes
- `src/kuhl_haus/mdp/components/__init__.py` — exports `FinlightDataListener`
- `tests/components/test_finlight_data_listener.py` — 19 tests: init, start/stop/restart lifecycle, exception paths, property sync to `connection_status`, reconnect logic, raw mode
- `pyproject.toml` — adds `finlight-client` dependency
- `README.rst` — FDL config env vars section