### PR TITLE
feat: FinlightDataQueues component

### DIFF
--- a/src/kuhl_haus/mdp/components/finlight_data_queues.py
+++ b/src/kuhl_haus/mdp/components/finlight_data_queues.py
@@ -1,0 +1,260 @@
+"""RabbitMQ publisher for Finlight WebSocket article messages.
+
+Routes incoming article messages from Finlight to a dedicated RabbitMQ queue.
+Uses a single per-queue channel for publishing to maximize throughput and
+minimize latency.
+"""
+import json
+import logging
+
+from datetime import datetime
+from typing import List, Dict, Union
+
+from aio_pika import Connection, Channel, connect_robust, Message
+from aio_pika import DeliveryMode
+from aio_pika.abc import AbstractConnection, AbstractChannel, AbstractExchange
+
+from kuhl_haus.mdp.enum.finlight_data_queue import FinlightDataQueue
+from kuhl_haus.mdp.helpers.observability import get_tracer, get_meter
+
+tracer = get_tracer(__name__)
+
+
+class FinlightDataQueues:
+    """Publish Finlight article messages to RabbitMQ with a dedicated channel.
+
+    Creates a dedicated RabbitMQ channel for the articles queue to publish
+    incoming article data with configurable TTL and delivery mode. Accepts
+    either Pydantic models (with model_dump) or plain dicts.
+
+    Uses NOT_PERSISTENT delivery mode to prioritize throughput over durability,
+    relying on queue TTL to expire unprocessed messages rather than fsync on
+    every publish. Designed for real-time pipelines where fresh data is more
+    valuable than stale data.
+    """
+    rabbitmq_url: str
+    queues: List[str]
+    message_ttl: int
+    publisher_confirms: bool
+    connection: Union[Connection, AbstractConnection]
+    channels: Dict[str, Union[Channel, AbstractChannel]]
+    exchanges: Dict[str, AbstractExchange]
+    connection_status: dict
+
+    def __init__(
+        self,
+        rabbitmq_url,
+        message_ttl: int,
+        publisher_confirms: bool = True
+    ):
+        self.logger = logging.getLogger(__name__)
+        self.rabbitmq_url = rabbitmq_url
+        self.queues = [
+            FinlightDataQueue.ARTICLES.value,
+        ]
+        self.message_ttl = message_ttl
+        self.publisher_confirms = publisher_confirms
+        self.channels = {}
+        self.exchanges = {}
+        self.connection_status = {
+            "connected": False,
+            "last_message_time": None,
+            "messages_received": 0,
+            FinlightDataQueue.ARTICLES.value: 0,
+            "reconnect_attempts": 0,
+        }
+        # Metrics
+        meter = get_meter(__name__)
+        self.error_counter = meter.create_counter(
+            name="fdq.error",
+            description=(
+                "Number of errors while processing messages "
+                "from the Finlight data provider"
+            ),
+            unit="1"
+        )
+        self.message_counter = meter.create_counter(
+            name="fdq.messages",
+            description=(
+                "Number of messages received from the Finlight data provider"
+            ),
+            unit="1"
+        )
+        self.counters = {
+            FinlightDataQueue.ARTICLES.value: meter.create_counter(
+                name=f"fdq.{FinlightDataQueue.ARTICLES.value}",
+                description=(
+                    "Number of articles received from the Finlight data provider"
+                ),
+                unit="1"
+            ),
+        }
+
+    @tracer.start_as_current_span("fdq.connect")
+    async def connect(self):
+        """Establish RabbitMQ connection and create a per-queue channel.
+
+        Opens a robust connection (auto-reconnect on failure), creates a dedicated
+        channel for the articles queue with publisher confirms enabled, and verifies
+        the target queue exists (passive declaration).
+
+        Side effects: Opens network socket; creates RabbitMQ channel.
+        """
+        self.connection = await connect_robust(self.rabbitmq_url)
+
+        # Create a dedicated channel per queue for parallel I/O
+        for q in self.queues:
+            channel = await self.connection.channel(
+                publisher_confirms=self.publisher_confirms,
+            )
+            self.channels[q] = channel
+            self.exchanges[q] = channel.default_exchange
+
+        try:
+            # Verify queues exist using the first available channel
+            first_channel = next(iter(self.channels.values()))
+            for q in self.queues:
+                _ = await first_channel.declare_queue(
+                    q, passive=True
+                )  # Don't create, just check
+
+            self.connection_status["connected"] = self.connection is not None
+        except Exception as e:
+            self.logger.error(f"Fatal error while processing request: {e}")
+            raise
+
+    @tracer.start_as_current_span("fdq.handle_message")
+    async def handle_message(self, article):
+        """Serialize and publish a single Finlight article to RabbitMQ.
+
+        Accepts a Pydantic model (with model_dump) or a plain dict. Serializes
+        to JSON, encodes to UTF-8 bytes, and publishes to the articles queue via
+        its dedicated channel.
+
+        Args:
+            article: A Pydantic model or dict representing the article data.
+
+        Side effects: Publishes to RabbitMQ; increments metrics counters.
+        """
+        if not self.channels:
+            self.logger.error("RabbitMQ channels not initialized")
+            raise Exception("RabbitMQ channels not initialized")
+        if not self.connection:
+            self.logger.error("RabbitMQ connection not initialized")
+            raise Exception("RabbitMQ connection not initialized")
+
+        if not hasattr(article, "model_dump") and not isinstance(article, dict):
+            raise Exception(
+                f"Invalid article type: expected pydantic model or dict, "
+                f"got {type(article).__name__}"
+            )
+
+        try:
+            self.message_counter.add(1)
+            self.connection_status["messages_received"] += 1
+            self.connection_status["last_message_time"] = (
+                datetime.now().isoformat()
+            )
+
+            if hasattr(article, "model_dump"):
+                serialized = json.dumps(article.model_dump())
+            else:
+                serialized = json.dumps(article)
+
+            encoded = serialized.encode()
+            rabbit_message = Message(
+                body=encoded,
+                # Persistent mode forces RabbitMQ to fsync to disk,
+                # which adds significant latency per message.
+                # Since we have short TTLs on the queues, the messages
+                # are ephemeral by nature.
+                delivery_mode=DeliveryMode.NOT_PERSISTENT,
+                content_type="application/json",
+                timestamp=datetime.now(),
+            )
+
+            await self._publish_message(
+                rabbit_message, FinlightDataQueue.ARTICLES.value
+            )
+        except Exception as e:
+            self.logger.error(f"Fatal error while processing message: {e}")
+            self.error_counter.add(1)
+            raise
+
+    @tracer.start_as_current_span("fdq._publish_message")
+    async def _publish_message(
+        self,
+        rabbit_message: Message,
+        queue_name: str
+    ):
+        """Publish message to RabbitMQ using the queue-specific channel.
+
+        Retrieves the exchange for the target queue and publishes with routing_key
+        equal to queue name (default exchange behavior). Logs errors but does not
+        raise to avoid failing the caller.
+
+        Side effects: Publishes to RabbitMQ; increments counter.
+        """
+        try:
+            exchange = self.exchanges[queue_name]
+            await exchange.publish(rabbit_message, routing_key=queue_name)
+            self.counters[queue_name].add(1)
+            self.connection_status[queue_name] += 1
+        except Exception as e:
+            self.logger.error(
+                f"Error publishing to RabbitMQ queue {queue_name}: {e}"
+            )
+
+    @tracer.start_as_current_span("fdq.shutdown")
+    async def shutdown(self):
+        """Close the channel and RabbitMQ connection.
+
+        Closes the articles channel, then closes the connection. Clears internal
+        state and marks the component as disconnected.
+
+        Side effects: Closes network sockets.
+        """
+        self.connection_status["connected"] = False
+        for queue_name, channel in self.channels.items():
+            self.logger.info(f"Closing RabbitMQ channel for {queue_name}")
+            await channel.close()
+            self.logger.info(f"RabbitMQ channel for {queue_name} closed")
+        self.channels.clear()
+        self.exchanges.clear()
+        self.logger.info("Closing RabbitMQ connection")
+        await self.connection.close()
+        self.logger.info("RabbitMQ connection closed")
+
+    @tracer.start_as_current_span("fdq.setup_queues")
+    async def setup_queues(self):
+        """Create the articles RabbitMQ queue with TTL and durability settings.
+
+        Called during deployment/setup to provision the queue. Opens connection,
+        creates a per-queue channel, and declares the queue with x-message-ttl.
+        Should be idempotent (queue settings must match if queue already exists).
+
+        Side effects: Creates durable RabbitMQ queue with configured TTL.
+        """
+        self.connection = await connect_robust(self.rabbitmq_url)
+
+        # Create a dedicated channel per queue
+        for queue in self.queues:
+            channel = await self.connection.channel(
+                publisher_confirms=self.publisher_confirms,
+            )
+            self.channels[queue] = channel
+            self.exchanges[queue] = channel.default_exchange
+
+            # Declare queue with message TTL
+            await channel.declare_queue(
+                queue,
+                durable=True,
+                arguments={"x-message-ttl": self.message_ttl}
+            )
+
+            self.logger.info(
+                f"{queue} queue created with {self.message_ttl}ms TTL "
+                "(channel dedicated)"
+            )
+
+        self.connection_status["connected"] = self.connection is not None

--- a/src/kuhl_haus/mdp/components/finlight_data_queues.py
+++ b/src/kuhl_haus/mdp/components/finlight_data_queues.py
@@ -50,7 +50,7 @@ class FinlightDataQueues:
         self.logger = logging.getLogger(__name__)
         self.rabbitmq_url = rabbitmq_url
         self.queues = [
-            FinlightDataQueue.ARTICLES.value,
+            FinlightDataQueue.NEWS.value,
         ]
         self.message_ttl = message_ttl
         self.publisher_confirms = publisher_confirms
@@ -60,7 +60,7 @@ class FinlightDataQueues:
             "connected": False,
             "last_message_time": None,
             "messages_received": 0,
-            FinlightDataQueue.ARTICLES.value: 0,
+            FinlightDataQueue.NEWS.value: 0,
             "reconnect_attempts": 0,
         }
         # Metrics
@@ -81,8 +81,8 @@ class FinlightDataQueues:
             unit="1"
         )
         self.counters = {
-            FinlightDataQueue.ARTICLES.value: meter.create_counter(
-                name=f"fdq.{FinlightDataQueue.ARTICLES.value}",
+            FinlightDataQueue.NEWS.value: meter.create_counter(
+                name=f"fdq.{FinlightDataQueue.NEWS.value}",
                 description=(
                     "Number of articles received from the Finlight data provider"
                 ),
@@ -174,7 +174,7 @@ class FinlightDataQueues:
             )
 
             await self._publish_message(
-                rabbit_message, FinlightDataQueue.ARTICLES.value
+                rabbit_message, FinlightDataQueue.NEWS.value
             )
         except Exception as e:
             self.logger.error(f"Fatal error while processing message: {e}")

--- a/src/kuhl_haus/mdp/enum/finlight_data_queue.py
+++ b/src/kuhl_haus/mdp/enum/finlight_data_queue.py
@@ -4,4 +4,4 @@ from enum import Enum
 
 class FinlightDataQueue(Enum):
     """Message type identifier for Finlight WebSocket article streams."""
-    ARTICLES = "finlight.articles"
+    NEWS = "news"

--- a/src/kuhl_haus/mdp/enum/finlight_data_queue.py
+++ b/src/kuhl_haus/mdp/enum/finlight_data_queue.py
@@ -1,0 +1,7 @@
+"""Queue identifier for routing Finlight news article messages."""
+from enum import Enum
+
+
+class FinlightDataQueue(Enum):
+    """Message type identifier for Finlight WebSocket article streams."""
+    ARTICLES = "finlight.articles"

--- a/tests/components/test_finlight_data_queues.py
+++ b/tests/components/test_finlight_data_queues.py
@@ -85,7 +85,7 @@ def test_fdq_init_with_valid_params_expect_correct_setup(sut):
     assert sut.rabbitmq_url == "amqp://guest:guest@localhost/"
     assert sut.message_ttl == 5000
     assert sut.publisher_confirms is True
-    assert FinlightDataQueue.ARTICLES.value in sut.queues
+    assert FinlightDataQueue.NEWS.value in sut.queues
 
 
 def test_fdq_init_with_valid_params_expect_connection_status_defaults(sut):
@@ -96,7 +96,7 @@ def test_fdq_init_with_valid_params_expect_connection_status_defaults(sut):
     assert sut.connection_status["messages_received"] == 0
     assert sut.connection_status["last_message_time"] is None
     assert sut.connection_status["reconnect_attempts"] == 0
-    assert sut.connection_status[FinlightDataQueue.ARTICLES.value] == 0
+    assert sut.connection_status[FinlightDataQueue.NEWS.value] == 0
 
 
 def test_fdq_init_with_publisher_confirms_false_expect_stored(mock_telemetry):
@@ -212,11 +212,11 @@ async def test_fdq_handle_message_with_pydantic_article_expect_published(
         mock_article.model_dump.assert_called_once()
         assert sut.connection_status["messages_received"] == 1
         assert sut.connection_status["last_message_time"] is not None
-        assert sut.connection_status[FinlightDataQueue.ARTICLES.value] == 1
-        exchange = sut.exchanges[FinlightDataQueue.ARTICLES.value]
+        assert sut.connection_status[FinlightDataQueue.NEWS.value] == 1
+        exchange = sut.exchanges[FinlightDataQueue.NEWS.value]
         exchange.publish.assert_awaited_once_with(
             mock_rabbit_msg,
-            routing_key=FinlightDataQueue.ARTICLES.value,
+            routing_key=FinlightDataQueue.NEWS.value,
         )
 
 
@@ -239,8 +239,8 @@ async def test_fdq_handle_message_with_dict_article_expect_published(
 
         # Assert
         assert sut.connection_status["messages_received"] == 1
-        assert sut.connection_status[FinlightDataQueue.ARTICLES.value] == 1
-        exchange = sut.exchanges[FinlightDataQueue.ARTICLES.value]
+        assert sut.connection_status[FinlightDataQueue.NEWS.value] == 1
+        exchange = sut.exchanges[FinlightDataQueue.NEWS.value]
         exchange.publish.assert_awaited_once()
 
 
@@ -290,7 +290,7 @@ async def test_fdq_handle_message_without_channels_expect_exception(sut):
 async def test_fdq_handle_message_with_no_connection_expect_exception(sut):
     """Channels dict is populated but underlying connection is None."""
     # Arrange
-    sut.channels = {FinlightDataQueue.ARTICLES.value: MagicMock()}
+    sut.channels = {FinlightDataQueue.NEWS.value: MagicMock()}
     sut.connection = None
 
     # Act & Assert
@@ -345,7 +345,7 @@ async def test_fdq_handle_message_twice_expect_counts_cumulative(
 
     # Assert
     assert sut.connection_status["messages_received"] == 2
-    assert sut.connection_status[FinlightDataQueue.ARTICLES.value] == 2
+    assert sut.connection_status[FinlightDataQueue.NEWS.value] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -359,16 +359,16 @@ async def test_fdq_publish_message_with_error_expect_logged_and_no_raise(
     # Arrange
     await sut.connect()
     mock_rabbit_msg = MagicMock()
-    sut.exchanges[FinlightDataQueue.ARTICLES.value].publish.side_effect = (
+    sut.exchanges[FinlightDataQueue.NEWS.value].publish.side_effect = (
         Exception("Pub Error")
     )
 
     # Act — must NOT raise
-    await sut._publish_message(mock_rabbit_msg, FinlightDataQueue.ARTICLES.value)
+    await sut._publish_message(mock_rabbit_msg, FinlightDataQueue.NEWS.value)
 
     # Assert — publish was attempted; per-queue counter was not incremented
-    sut.exchanges[FinlightDataQueue.ARTICLES.value].publish.assert_called_once()
-    assert sut.connection_status[FinlightDataQueue.ARTICLES.value] == 0
+    sut.exchanges[FinlightDataQueue.NEWS.value].publish.assert_called_once()
+    assert sut.connection_status[FinlightDataQueue.NEWS.value] == 0
 
 
 @pytest.mark.asyncio
@@ -386,7 +386,7 @@ async def test_fdq_publish_message_with_channel_closed_expect_error_logged(
     with caplog.at_level(logging.ERROR):
         await sut._publish_message(
             rabbit_message=msg,
-            queue_name=FinlightDataQueue.ARTICLES.value,
+            queue_name=FinlightDataQueue.NEWS.value,
         )
 
     # Assert — error was logged, not propagated
@@ -453,7 +453,7 @@ async def test_fdq_setup_queues_with_custom_ttl_expect_ttl_passed(
 
     # Assert
     mock_aio_pika["channel"].declare_queue.assert_any_call(
-        FinlightDataQueue.ARTICLES.value,
+        FinlightDataQueue.NEWS.value,
         durable=True,
         arguments={"x-message-ttl": custom_ttl},
     )

--- a/tests/components/test_finlight_data_queues.py
+++ b/tests/components/test_finlight_data_queues.py
@@ -1,0 +1,473 @@
+"""Unit tests for FinlightDataQueues — TDD red phase.
+
+Tests are written against the expected public interface before the implementation
+exists. All tests should fail until the implementation is provided.
+"""
+import json
+import logging
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from kuhl_haus.mdp.components.finlight_data_queues import FinlightDataQueues
+from kuhl_haus.mdp.enum.finlight_data_queue import FinlightDataQueue
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_aio_pika():
+    """Mock aio_pika connection, channel, and exchange layer."""
+    with patch(
+        "kuhl_haus.mdp.components.finlight_data_queues.connect_robust",
+        new_callable=AsyncMock,
+    ) as mock_connect:
+        mock_connection = AsyncMock()
+        mock_connect.return_value = mock_connection
+
+        mock_channel = AsyncMock()
+        mock_connection.channel.return_value = mock_channel
+
+        mock_exchange = AsyncMock()
+        mock_channel.default_exchange = mock_exchange
+
+        yield {
+            "connect": mock_connect,
+            "connection": mock_connection,
+            "channel": mock_channel,
+            "exchange": mock_exchange,
+        }
+
+
+@pytest.fixture
+def mock_telemetry():
+    """Mock OpenTelemetry tracer and meter so no real OTEL pipeline is needed."""
+    with patch(
+        "kuhl_haus.mdp.components.finlight_data_queues.get_meter"
+    ) as mock_get_meter, patch(
+        "kuhl_haus.mdp.components.finlight_data_queues.get_tracer"
+    ) as mock_get_tracer:
+        mock_meter = MagicMock()
+        mock_get_meter.return_value = mock_meter
+
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+
+        mock_tracer = MagicMock()
+        mock_get_tracer.return_value = mock_tracer
+
+        yield {
+            "meter": mock_meter,
+            "counter": mock_counter,
+            "tracer": mock_tracer,
+        }
+
+
+@pytest.fixture
+def sut(mock_telemetry):
+    """Subject Under Test: FinlightDataQueues with telemetry mocked."""
+    return FinlightDataQueues(
+        rabbitmq_url="amqp://guest:guest@localhost/",
+        message_ttl=5000,
+        publisher_confirms=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+def test_fdq_init_with_valid_params_expect_correct_setup(sut):
+    # Arrange & Act (done by sut fixture)
+
+    # Assert
+    assert sut.rabbitmq_url == "amqp://guest:guest@localhost/"
+    assert sut.message_ttl == 5000
+    assert sut.publisher_confirms is True
+    assert FinlightDataQueue.ARTICLES.value in sut.queues
+
+
+def test_fdq_init_with_valid_params_expect_connection_status_defaults(sut):
+    # Arrange & Act (done by sut fixture)
+
+    # Assert
+    assert sut.connection_status["connected"] is False
+    assert sut.connection_status["messages_received"] == 0
+    assert sut.connection_status["last_message_time"] is None
+    assert sut.connection_status["reconnect_attempts"] == 0
+    assert sut.connection_status[FinlightDataQueue.ARTICLES.value] == 0
+
+
+def test_fdq_init_with_publisher_confirms_false_expect_stored(mock_telemetry):
+    # Arrange & Act
+    fdq = FinlightDataQueues(
+        rabbitmq_url="amqp://guest:guest@localhost/",
+        message_ttl=1000,
+        publisher_confirms=False,
+    )
+
+    # Assert
+    assert fdq.publisher_confirms is False
+
+
+# ---------------------------------------------------------------------------
+# connect()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fdq_connect_with_success_expect_connected(sut, mock_aio_pika):
+    # Arrange
+    # (mock_aio_pika handles the happy path)
+
+    # Act
+    await sut.connect()
+
+    # Assert
+    mock_aio_pika["connect"].assert_called_once_with(sut.rabbitmq_url)
+    assert len(sut.channels) == len(sut.queues)
+    assert sut.connection_status["connected"] is True
+
+
+@pytest.mark.asyncio
+async def test_fdq_connect_with_success_expect_queues_passively_declared(
+    sut, mock_aio_pika
+):
+    """connect() must verify all queues exist via passive declare."""
+    # Arrange
+    # (mock_aio_pika handles the happy path)
+
+    # Act
+    await sut.connect()
+
+    # Assert — one passive declare per queue
+    assert mock_aio_pika["channel"].declare_queue.call_count == len(sut.queues)
+
+
+@pytest.mark.asyncio
+async def test_fdq_connect_with_connection_error_expect_exception_raised(
+    sut, mock_aio_pika
+):
+    # Arrange
+    mock_aio_pika["connect"].side_effect = Exception("Connection refused")
+
+    # Act & Assert
+    with pytest.raises(Exception, match="Connection refused"):
+        await sut.connect()
+
+
+@pytest.mark.asyncio
+async def test_fdq_connect_with_declare_queue_error_expect_exception_raised(
+    sut, mock_aio_pika
+):
+    # Arrange
+    mock_aio_pika["channel"].declare_queue.side_effect = Exception(
+        "Queue not found"
+    )
+
+    # Act & Assert
+    with pytest.raises(Exception, match="Queue not found"):
+        await sut.connect()
+
+
+@pytest.mark.asyncio
+async def test_fdq_connect_with_declare_error_expect_status_not_connected(
+    sut, mock_aio_pika
+):
+    """If declare_queue fails, connection_status must not be flipped to True."""
+    # Arrange
+    mock_aio_pika["channel"].declare_queue.side_effect = Exception("Boom")
+
+    # Act
+    with pytest.raises(Exception):
+        await sut.connect()
+
+    # Assert
+    assert sut.connection_status["connected"] is False
+
+
+# ---------------------------------------------------------------------------
+# handle_message()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fdq_handle_message_with_pydantic_article_expect_published(
+    sut, mock_aio_pika, mock_telemetry
+):
+    # Arrange
+    await sut.connect()
+    mock_article = MagicMock()
+    mock_article.model_dump.return_value = {"title": "Test Article", "id": 1}
+
+    with patch(
+        "kuhl_haus.mdp.components.finlight_data_queues.Message"
+    ) as mock_msg_class:
+        mock_rabbit_msg = MagicMock()
+        mock_msg_class.return_value = mock_rabbit_msg
+
+        # Act
+        await sut.handle_message(mock_article)
+
+        # Assert
+        mock_article.model_dump.assert_called_once()
+        assert sut.connection_status["messages_received"] == 1
+        assert sut.connection_status["last_message_time"] is not None
+        assert sut.connection_status[FinlightDataQueue.ARTICLES.value] == 1
+        exchange = sut.exchanges[FinlightDataQueue.ARTICLES.value]
+        exchange.publish.assert_awaited_once_with(
+            mock_rabbit_msg,
+            routing_key=FinlightDataQueue.ARTICLES.value,
+        )
+
+
+@pytest.mark.asyncio
+async def test_fdq_handle_message_with_dict_article_expect_published(
+    sut, mock_aio_pika
+):
+    """dict input must be serialized via json.dumps without calling model_dump."""
+    # Arrange
+    await sut.connect()
+    article_dict = {"title": "Dict Article", "ticker": "AAPL"}
+
+    with patch(
+        "kuhl_haus.mdp.components.finlight_data_queues.Message"
+    ) as mock_msg_class:
+        mock_msg_class.return_value = MagicMock()
+
+        # Act
+        await sut.handle_message(article_dict)
+
+        # Assert
+        assert sut.connection_status["messages_received"] == 1
+        assert sut.connection_status[FinlightDataQueue.ARTICLES.value] == 1
+        exchange = sut.exchanges[FinlightDataQueue.ARTICLES.value]
+        exchange.publish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdq_handle_message_with_pydantic_article_expect_bytes_body(
+    sut, mock_aio_pika
+):
+    """Message body must be UTF-8 encoded bytes, not a raw string."""
+    # Arrange
+    await sut.connect()
+    article_data = {"title": "Encoding Test", "id": 42}
+    mock_article = MagicMock()
+    mock_article.model_dump.return_value = article_data
+
+    captured_bodies = []
+
+    with patch(
+        "kuhl_haus.mdp.components.finlight_data_queues.Message"
+    ) as mock_msg_class:
+        def capture_message(**kwargs):
+            captured_bodies.append(kwargs.get("body"))
+            return MagicMock()
+
+        mock_msg_class.side_effect = capture_message
+
+        # Act
+        await sut.handle_message(mock_article)
+
+    # Assert
+    assert len(captured_bodies) == 1
+    assert isinstance(captured_bodies[0], bytes)
+    assert json.loads(captured_bodies[0]) == article_data
+
+
+@pytest.mark.asyncio
+async def test_fdq_handle_message_without_channels_expect_exception(sut):
+    # Arrange — simulate pre-connect state
+    sut.channels = {}
+    sut.connection = None
+
+    # Act & Assert
+    with pytest.raises(Exception, match="RabbitMQ channels not initialized"):
+        await sut.handle_message(MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_fdq_handle_message_with_no_connection_expect_exception(sut):
+    """Channels dict is populated but underlying connection is None."""
+    # Arrange
+    sut.channels = {FinlightDataQueue.ARTICLES.value: MagicMock()}
+    sut.connection = None
+
+    # Act & Assert
+    with pytest.raises(Exception, match="RabbitMQ connection not initialized"):
+        await sut.handle_message(MagicMock())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_input", [None, 123])
+async def test_fdq_handle_message_with_invalid_input_expect_exception(
+    sut, mock_aio_pika, invalid_input
+):
+    # Arrange
+    await sut.connect()
+
+    # Act & Assert
+    with pytest.raises(Exception):
+        await sut.handle_message(invalid_input)
+
+
+@pytest.mark.asyncio
+async def test_fdq_handle_message_with_serialization_error_expect_error_counter_incremented(
+    sut, mock_aio_pika, mock_telemetry
+):
+    """Serialization failures must increment the error counter and re-raise."""
+    # Arrange
+    await sut.connect()
+    mock_article = MagicMock()
+    mock_article.model_dump.side_effect = Exception("Serialization failed")
+
+    # Act & Assert
+    with pytest.raises(Exception, match="Serialization failed"):
+        await sut.handle_message(mock_article)
+
+    mock_telemetry["counter"].add.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_fdq_handle_message_twice_expect_counts_cumulative(
+    sut, mock_aio_pika
+):
+    """Each call to handle_message increments messages_received independently."""
+    # Arrange
+    await sut.connect()
+    mock_article = MagicMock()
+    mock_article.model_dump.return_value = {"title": "A"}
+
+    with patch("kuhl_haus.mdp.components.finlight_data_queues.Message"):
+        # Act
+        await sut.handle_message(mock_article)
+        await sut.handle_message(mock_article)
+
+    # Assert
+    assert sut.connection_status["messages_received"] == 2
+    assert sut.connection_status[FinlightDataQueue.ARTICLES.value] == 2
+
+
+# ---------------------------------------------------------------------------
+# _publish_message()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fdq_publish_message_with_error_expect_logged_and_no_raise(
+    sut, mock_aio_pika
+):
+    # Arrange
+    await sut.connect()
+    mock_rabbit_msg = MagicMock()
+    sut.exchanges[FinlightDataQueue.ARTICLES.value].publish.side_effect = (
+        Exception("Pub Error")
+    )
+
+    # Act — must NOT raise
+    await sut._publish_message(mock_rabbit_msg, FinlightDataQueue.ARTICLES.value)
+
+    # Assert — publish was attempted; per-queue counter was not incremented
+    sut.exchanges[FinlightDataQueue.ARTICLES.value].publish.assert_called_once()
+    assert sut.connection_status[FinlightDataQueue.ARTICLES.value] == 0
+
+
+@pytest.mark.asyncio
+async def test_fdq_publish_message_with_channel_closed_expect_error_logged(
+    sut, mock_aio_pika, caplog
+):
+    # Arrange
+    await sut.connect()
+    mock_aio_pika["channel"].default_exchange.publish = AsyncMock(
+        side_effect=ConnectionError("channel closed")
+    )
+    msg = MagicMock()
+
+    # Act
+    with caplog.at_level(logging.ERROR):
+        await sut._publish_message(
+            rabbit_message=msg,
+            queue_name=FinlightDataQueue.ARTICLES.value,
+        )
+
+    # Assert — error was logged, not propagated
+    assert "channel closed" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# shutdown()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fdq_shutdown_with_active_conn_expect_closed(sut, mock_aio_pika):
+    # Arrange
+    await sut.connect()
+    connection = sut.connection
+
+    # Act
+    await sut.shutdown()
+
+    # Assert
+    assert sut.connection_status["connected"] is False
+    assert len(sut.channels) == 0
+    assert len(sut.exchanges) == 0
+    assert mock_aio_pika["channel"].close.await_count == len(sut.queues)
+    connection.close.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# setup_queues()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fdq_setup_queues_with_valid_params_expect_queues_declared(
+    sut, mock_aio_pika
+):
+    # Arrange
+    # (mock_aio_pika handles the happy path)
+
+    # Act
+    await sut.setup_queues()
+
+    # Assert
+    assert sut.connection_status["connected"] is True
+    for q in sut.queues:
+        mock_aio_pika["channel"].declare_queue.assert_any_call(
+            q, durable=True, arguments={"x-message-ttl": sut.message_ttl}
+        )
+
+
+@pytest.mark.asyncio
+async def test_fdq_setup_queues_with_custom_ttl_expect_ttl_passed(
+    mock_telemetry, mock_aio_pika
+):
+    """TTL supplied at init must flow through to the queue declaration."""
+    # Arrange
+    custom_ttl = 10_000
+    fdq = FinlightDataQueues(
+        rabbitmq_url="amqp://guest:guest@localhost/",
+        message_ttl=custom_ttl,
+    )
+
+    # Act
+    await fdq.setup_queues()
+
+    # Assert
+    mock_aio_pika["channel"].declare_queue.assert_any_call(
+        FinlightDataQueue.ARTICLES.value,
+        durable=True,
+        arguments={"x-message-ttl": custom_ttl},
+    )
+
+
+@pytest.mark.asyncio
+async def test_fdq_setup_queues_expect_connected_status_set(
+    sut, mock_aio_pika
+):
+    # Arrange
+    assert sut.connection_status["connected"] is False
+
+    # Act
+    await sut.setup_queues()
+
+    # Assert
+    assert sut.connection_status["connected"] is True


### PR DESCRIPTION
Closes #20

## Summary

Implements `FinlightDataQueues` — a RabbitMQ publisher for Finlight WebSocket article messages, mirroring the `MassiveDataQueues` pattern.

## New files

- `src/kuhl_haus/mdp/enum/finlight_data_queue.py` — `FinlightDataQueue` enum (`ARTICLES = "finlight.articles"`)
- `src/kuhl_haus/mdp/components/finlight_data_queues.py` — `FinlightDataQueues` class
- `tests/components/test_finlight_data_queues.py` — 23 unit tests (100% branch coverage)

## Design

- Single queue: `finlight.articles`
- `handle_message(article)` — async; accepts Pydantic models (`model_dump`) or plain dicts; validates type; serializes to UTF-8 JSON; publishes NOT_PERSISTENT to dedicated channel
- `connect()`, `shutdown()`, `setup_queues()`, `_publish_message()` — mirror `MassiveDataQueues` exactly
- OpenTelemetry metrics with `fdq.` prefix
- `FinlightDataListener` receives `handle_message` as its `on_article` callback

## TDD Process

Per team standards:
1. **Commit 1** (`c983203`): Test file written first — all tests failing (red phase)
2. **Commit 2** (`447b100`): Implementation written to make all tests pass (green phase)

## Test results

```
23 passed in 0.27s
Branch coverage: 100%
```