### PR TITLE
feat: FinlightDataProcessor component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,18 @@ Test files live in `tests/`. Uses `pytest-asyncio` for async test support.
 - All PRs target `mainline`; use feature branches for all changes
 - Version tags drive PyPI releases — tag format: `vX.Y.Z`
 
+## Commit Authorship
+
+Every commit must include this trailer — replace `noreply@anthropic.com` with the human author:
+
+```
+Co-Authored-By: Tom Pounders <git@oldschool.engineer>
+```
+
+- **Do NOT** use `Co-Authored-By: Claude ... <noreply@anthropic.com>`
+- **Do NOT** add `🤖 Generated with Claude Code` to PR descriptions
+- The correct trailer is always `Co-Authored-By: Tom Pounders <git@oldschool.engineer>`
+
 ## Documentation
 
 Built with Sphinx + Furo theme. Hosted on Read the Docs.

--- a/src/kuhl_haus/mdp/components/finlight_data_processor.py
+++ b/src/kuhl_haus/mdp/components/finlight_data_processor.py
@@ -1,0 +1,337 @@
+"""RabbitMQ consumer that processes Finlight news articles through pluggable analyzers.
+
+Pulls messages from a dedicated RabbitMQ queue, deserializes JSON news articles,
+delegates analysis, and publishes results to Redis. Designed for high-throughput
+scenarios where multiple processors can scale horizontally, each consuming from
+the same queue with automatic load balancing.
+"""
+import asyncio
+import json
+import logging
+from typing import Any, Optional
+
+import aio_pika
+import redis.asyncio as aioredis
+from aio_pika.abc import AbstractIncomingMessage
+
+from kuhl_haus.mdp.analyzers.analyzer import Analyzer, AnalyzerOptions
+from kuhl_haus.mdp.components.market_data_cache import MarketDataCache
+from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
+from kuhl_haus.mdp.exceptions.data_analysis_exception import DataAnalysisException
+from kuhl_haus.mdp.helpers.observability import get_tracer, get_meter
+from kuhl_haus.mdp.helpers.structured_logging import setup_logging
+
+tracer = get_tracer(__name__)
+
+
+class FinlightDataProcessor:
+    """Consume RabbitMQ Finlight news queue with async concurrency control.
+
+    Connects to RabbitMQ and Redis, consumes messages from a single queue (e.g.,
+    'news'), deserializes JSON articles, passes through an Analyzer subclass,
+    and writes results to Redis cache with pub/sub notifications. Prefetch and
+    semaphore-based concurrency prevent memory exhaustion during traffic spikes.
+
+    Rehydration from Redis cache occurs on startup to restore analyzer state after
+    restarts. Graceful shutdown waits for in-flight tasks to complete.
+
+    Concurrency: Uses asyncio.Semaphore (default 500) to cap concurrent message
+    processing; prefetch_count (default 100) controls how many messages RabbitMQ
+    delivers before waiting for ACKs.
+    """
+    queue_name: str
+    mdq_connected: bool
+    mdc_connected: bool
+    processed: int
+    processing_error: int
+    decoding_error: int
+    published: int
+    error: int
+
+    def __init__(
+        self,
+        rabbitmq_url: str,
+        queue_name: str,
+        redis_url: str,
+        analyzer_class: Any,
+        prefetch_count: int = 100,  # Higher for async throughput
+        max_concurrent_tasks: int = 500,  # Concurrent processing limit
+    ):
+        self.rabbitmq_url = rabbitmq_url
+        self.queue_name = queue_name
+        self.redis_url = redis_url
+        self.prefetch_count = prefetch_count
+        self.max_concurrent_tasks = max_concurrent_tasks
+
+        # Connection objects
+        self.rmq_connection = None
+        self.rmq_channel = None
+        self.redis_client = None
+        self.mdc: Optional[MarketDataCache] = None
+
+        # Analyzer
+        self.analyzer: Analyzer = None
+        self.analyzer_class = analyzer_class
+        self.analyzer_options = AnalyzerOptions(redis_url=redis_url)
+
+        # Concurrency control
+        self.semaphore = asyncio.Semaphore(max_concurrent_tasks)
+        self.processing_tasks = set()
+
+        # State
+        self.running = False
+
+        # Logging
+        setup_logging()
+        self.logger = logging.getLogger(__name__)
+
+        # Metrics
+        meter = get_meter(__name__)
+        self.processed_counter = meter.create_counter(
+            name="fdp.processed",
+            description="Number of processed messages",
+            unit="1"
+        )
+        self.processed = 0
+        self.processing_error_counter = meter.create_counter(
+            name="fdp.processing_error",
+            description="Number of messages with processing errors",
+            unit="1"
+        )
+        self.processing_error = 0
+        self.error_counter = meter.create_counter(
+            name="fdp.error",
+            description="Number of messages with other errors",
+            unit="1"
+        )
+        self.error = 0
+        self.decoding_error_counter = meter.create_counter(
+            name="fdp.decoding_error",
+            description="Number of messages with JSON decoding errors",
+            unit="1"
+        )
+        self.decoding_error = 0
+        self.published_counter = meter.create_counter(
+            name="fdp.published",
+            description="Number of messages published to Redis",
+            unit="1"
+        )
+        self.published = 0
+        self.mdq_connected = False
+        self.mdc_connected = False
+
+    @tracer.start_as_current_span("fdp.connect")
+    async def connect(self, force: bool = False):
+        """Establish async connections to RabbitMQ and Redis.
+
+        Creates RabbitMQ channel with prefetch QoS, verifies target queue exists,
+        creates Redis connection pool, and tests connectivity via PING.
+
+        Args:
+            force: Reconnect even if already connected.
+        """
+
+        if not self.mdq_connected or force:
+            # RabbitMQ connection
+            try:
+                self.rmq_connection = await aio_pika.connect_robust(
+                    self.rabbitmq_url,
+                    heartbeat=60,
+                    timeout=30,
+                )
+                self.rmq_channel = await self.rmq_connection.channel()
+                await self.rmq_channel.set_qos(prefetch_count=self.prefetch_count)
+                await self.rmq_channel.get_queue(self.queue_name, ensure=False)
+                self.mdq_connected = True
+                self.logger.info(f"Connected to RabbitMQ queue: {self.queue_name}")
+            except Exception as e:
+                self.logger.error(f"Failed to connect to RabbitMQ: {e}")
+                raise
+
+        if not self.mdc_connected or force:
+            # Redis connection pool
+            try:
+                self.redis_client = aioredis.from_url(
+                    self.redis_url,
+                    encoding="utf-8",
+                    decode_responses=True,
+                    max_connections=1000,
+                    socket_connect_timeout=10,
+                )
+
+                # Test Redis connection
+                await self.redis_client.ping()
+                self.mdc_connected = True
+                self.logger.debug(f"Connected to Redis: {self.redis_url}")
+            except Exception as e:
+                self.logger.error(f"Failed to connect to Redis: {e}")
+                # Cleanup RabbitMQ connection on Redis failure
+                await self.rmq_channel.close()
+                await self.rmq_connection.close()
+                raise
+
+    @tracer.start_as_current_span("fdp.process_message")
+    async def _process_message(self, message: AbstractIncomingMessage):
+        """Deserialize, analyze, and cache a single RabbitMQ message.
+
+        Acquires semaphore slot, decodes message body as JSON, delegates to
+        analyzer.analyze_data, and writes results to Redis. ACKs message on
+        success; logs errors and ACKs on failure (no requeue to avoid poison messages).
+
+        Called concurrently (up to max_concurrent_tasks) from _callback.
+
+        Side effects: Writes to Redis (SET + PUBLISH per result); ACKs RabbitMQ message.
+        """
+        async with self.semaphore:
+            try:
+                async with message.process():
+                    # Parse message — pass dict directly (no WebSocketMessageSerde)
+                    data = json.loads(message.body.decode())
+
+                    # Delegate to analyzer
+                    analyzer_results = await self.analyzer.analyze_data(data)
+                    self.processed_counter.add(1)
+                    self.processed += 1
+                    self.logger.debug(f"Processed message {message.delivery_tag}")
+
+                    # The analyzer throttles downstream publication rates.
+                    # The analyzer will return None or an empty array if it is not ready to publish.
+                    if analyzer_results:
+                        for analyzer_result in analyzer_results:
+                            self.published_counter.add(1)
+                            self.published += 1
+                            await self._cache_result(analyzer_result)
+            except DataAnalysisException as e:
+                self.logger.error(f"Message processing error: {e}", exc_info=True)
+                self.processing_error_counter.add(1)
+                self.processing_error += 1
+            except json.JSONDecodeError as e:
+                self.logger.error(f"JSON decode error: {e}")
+                self.decoding_error_counter.add(1)
+                self.decoding_error += 1
+            except Exception as e:
+                self.logger.error(f"Unhandled processing error: {e}", exc_info=True)
+                self.error_counter.add(1)
+                self.error += 1
+
+    @tracer.start_as_current_span("fdp.callback")
+    async def _callback(self, message: AbstractIncomingMessage):
+        """RabbitMQ callback that spawns async processing task.
+
+        Creates a task for _process_message, adds it to processing_tasks set for
+        graceful shutdown tracking, and auto-discards it on completion.
+
+        Called by aio_pika for each message delivered by RabbitMQ.
+        """
+        task = asyncio.create_task(self._process_message(message))
+        self.processing_tasks.add(task)
+        task.add_done_callback(self.processing_tasks.discard)
+
+    @tracer.start_as_current_span("fdp.cache_result")
+    async def _cache_result(self, analyzer_result: MarketDataAnalyzerResult):
+        """Write analyzer output to Redis and publish notification.
+
+        Uses a non-transactional pipeline to SET the cache key (with optional TTL)
+        and PUBLISH to the notification channel. Both operations execute atomically
+        from a network perspective (single pipeline).
+
+        Args:
+            analyzer_result: Contains cache_key, cache_ttl, publish_key, and data.
+
+        Side effects: Writes to Redis (SET + PUBLISH).
+        """
+        result_json = json.dumps(analyzer_result.data)
+
+        # Pipeline - no async context manager, no await on queue methods
+        pipe = self.redis_client.pipeline(transaction=False)
+        if analyzer_result.cache_key:
+            if analyzer_result.cache_ttl > 0:
+                pipe.setex(analyzer_result.cache_key, analyzer_result.cache_ttl, result_json)
+            else:
+                pipe.set(analyzer_result.cache_key, result_json)
+        if analyzer_result.publish_key:
+            pipe.publish(analyzer_result.publish_key, result_json)
+
+        await pipe.execute()
+
+        self.logger.debug(f"Cached result for {analyzer_result.cache_key}")
+
+    @tracer.start_as_current_span("fdp.start")
+    async def start(self):
+        """Connect, rehydrate analyzer state, and begin consuming RabbitMQ queue.
+
+        Retries connection up to 5 times with exponential backoff, instantiates
+        analyzer and rehydrates from cache, then starts consuming messages via
+        _callback. Blocks until self.running is set to False or CancelledError.
+
+        Side effects: Spawns background message processing tasks; writes to Redis
+        during analyzer rehydration.
+        """
+        retry_count = 0
+        while not self.mdc_connected or not self.mdq_connected:
+            try:
+                await self.connect()
+            except Exception as e:
+                if retry_count < 5:
+                    retry_count += 1
+                    self.logger.error(f"Connection error: {e}, sleeping for {2 * retry_count}s")
+                    await asyncio.sleep(2 * retry_count)
+                else:
+                    self.logger.error("Failed to connect to RabbitMQ or Redis")
+                    raise
+        self.running = True
+
+        self.analyzer = self.analyzer_class(options=self.analyzer_options)
+        self.logger.info(f"{self.analyzer_class} rehydrating from cache")
+        await self.analyzer.rehydrate()
+        self.logger.info(f"{self.analyzer_class} rehydration complete")
+
+        # Get queue
+        queue = await self.rmq_channel.get_queue(self.queue_name)
+
+        self.logger.info("Starting async message consumption")
+
+        # Start consuming with callback
+        await queue.consume(self._callback, no_ack=False)
+
+        # Run until shutdown signal
+        try:
+            while self.running:
+                await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            self.logger.info("Consumption cancelled")
+        finally:
+            await self.stop()
+
+    @tracer.start_as_current_span("fdp.stop")
+    async def stop(self):
+        """Wait for in-flight tasks and close connections.
+
+        Sets running=False, waits for all processing_tasks to complete, then closes
+        RabbitMQ channel/connection and Redis client. Ensures no messages are lost
+        during shutdown.
+
+        Side effects: Closes network sockets; logs final metrics.
+        """
+        self.logger.info("Stopping processor - waiting for pending tasks")
+        self.running = False
+
+        # Wait for all processing tasks to complete
+        if self.processing_tasks:
+            self.logger.info(f"Waiting for {len(self.processing_tasks)} tasks")
+            await asyncio.gather(*self.processing_tasks, return_exceptions=True)
+
+        # Close connections
+        if self.rmq_channel:
+            await self.rmq_channel.close()
+
+        if self.rmq_connection:
+            await self.rmq_connection.close()
+
+        if self.redis_client:
+            await self.redis_client.close()
+
+        self.logger.info(
+            f"Processor stopped - Processed: {self.processed}, "
+            f"Errors: {self.error}"
+        )

--- a/tests/components/test_finlight_data_processor.py
+++ b/tests/components/test_finlight_data_processor.py
@@ -1,0 +1,792 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aio_pika.abc import AbstractIncomingMessage
+
+from kuhl_haus.mdp.data.market_data_analyzer_result import (
+    MarketDataAnalyzerResult,
+)
+from kuhl_haus.mdp.exceptions.data_analysis_exception import (
+    DataAnalysisException,
+)
+
+MODULE = "kuhl_haus.mdp.components.finlight_data_processor"
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_meter():
+    with patch(f"{MODULE}.get_meter") as m:
+        meter = MagicMock()
+        meter.create_counter.return_value = MagicMock()
+        m.return_value = meter
+        yield meter
+
+
+@pytest.fixture
+def mock_setup_logging():
+    with patch(f"{MODULE}.setup_logging"):
+        yield
+
+
+@pytest.fixture
+def mock_analyzer_class():
+    cls = MagicMock()
+    instance = MagicMock()
+    instance.analyze_data = AsyncMock(return_value=None)
+    instance.rehydrate = AsyncMock()
+    cls.return_value = instance
+    return cls
+
+
+@pytest.fixture
+def sut(mock_meter, mock_setup_logging, mock_analyzer_class):
+    from kuhl_haus.mdp.components.finlight_data_processor import (
+        FinlightDataProcessor,
+    )
+
+    return FinlightDataProcessor(
+        rabbitmq_url="amqp://guest:guest@localhost/",
+        queue_name="news",
+        redis_url="redis://localhost",
+        analyzer_class=mock_analyzer_class,
+        prefetch_count=50,
+        max_concurrent_tasks=100,
+    )
+
+
+# ── __init__ ────────────────────────────────────────────────────────
+
+
+def test_fdp_init_with_valid_params_expect_attrs_set(
+    mock_meter, mock_setup_logging, mock_analyzer_class
+):
+    # Arrange / Act
+    from kuhl_haus.mdp.components.finlight_data_processor import (
+        FinlightDataProcessor,
+    )
+
+    sut = FinlightDataProcessor(
+        rabbitmq_url="amqp://localhost/",
+        queue_name="news",
+        redis_url="redis://localhost",
+        analyzer_class=mock_analyzer_class,
+        prefetch_count=10,
+        max_concurrent_tasks=20,
+    )
+
+    # Assert
+    assert sut.rabbitmq_url == "amqp://localhost/"
+    assert sut.queue_name == "news"
+    assert sut.redis_url == "redis://localhost"
+    assert sut.prefetch_count == 10
+    assert sut.max_concurrent_tasks == 20
+    assert sut.processed == 0
+    assert sut.processing_error == 0
+    assert sut.decoding_error == 0
+    assert sut.published == 0
+    assert sut.error == 0
+    assert sut.running is False
+    assert sut.mdq_connected is False
+    assert sut.mdc_connected is False
+    assert sut.rmq_connection is None
+    assert sut.rmq_channel is None
+    assert sut.redis_client is None
+
+
+def test_fdp_init_with_no_massive_api_key_expect_no_attr(
+    mock_meter, mock_setup_logging, mock_analyzer_class
+):
+    # Arrange / Act
+    from kuhl_haus.mdp.components.finlight_data_processor import (
+        FinlightDataProcessor,
+    )
+
+    sut = FinlightDataProcessor(
+        rabbitmq_url="amqp://localhost/",
+        queue_name="news",
+        redis_url="redis://localhost",
+        analyzer_class=mock_analyzer_class,
+    )
+
+    # Assert — no massive_api_key attribute on FDP
+    assert not hasattr(sut, "massive_api_key")
+
+
+def test_fdp_init_with_defaults_expect_default_concurrency(
+    mock_meter, mock_setup_logging, mock_analyzer_class
+):
+    # Arrange / Act
+    from kuhl_haus.mdp.components.finlight_data_processor import (
+        FinlightDataProcessor,
+    )
+
+    sut = FinlightDataProcessor(
+        rabbitmq_url="amqp://localhost/",
+        queue_name="news",
+        redis_url="redis://localhost",
+        analyzer_class=mock_analyzer_class,
+    )
+
+    # Assert
+    assert sut.prefetch_count == 100
+    assert sut.max_concurrent_tasks == 500
+
+
+def test_fdp_init_expect_fdp_metric_prefix(
+    mock_meter, mock_setup_logging, mock_analyzer_class
+):
+    # Arrange / Act
+    from kuhl_haus.mdp.components.finlight_data_processor import (
+        FinlightDataProcessor,
+    )
+
+    FinlightDataProcessor(
+        rabbitmq_url="amqp://localhost/",
+        queue_name="news",
+        redis_url="redis://localhost",
+        analyzer_class=mock_analyzer_class,
+    )
+
+    # Assert — all counters use "fdp." prefix
+    created_names = [
+        call.kwargs.get("name") or call.args[0]
+        for call in mock_meter.create_counter.call_args_list
+    ]
+    assert all(name.startswith("fdp.") for name in created_names), (
+        f"Expected all counters to start with 'fdp.', got: {created_names}"
+    )
+
+
+# ── connect ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fdp_connect_with_fresh_state_expect_both_connected(sut):
+    # Arrange
+    mock_rmq_conn = AsyncMock()
+    mock_rmq_channel = AsyncMock()
+    mock_rmq_conn.channel.return_value = mock_rmq_channel
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock()
+
+    with patch(
+        f"{MODULE}.aio_pika.connect_robust",
+        new_callable=AsyncMock,
+        return_value=mock_rmq_conn,
+    ), patch(
+        f"{MODULE}.aioredis.from_url",
+        return_value=mock_redis,
+    ):
+        # Act
+        await sut.connect()
+
+    # Assert
+    assert sut.mdq_connected is True
+    assert sut.mdc_connected is True
+    assert sut.rmq_connection is mock_rmq_conn
+    assert sut.rmq_channel is mock_rmq_channel
+    assert sut.redis_client is mock_redis
+    mock_rmq_channel.set_qos.assert_awaited_once_with(
+        prefetch_count=sut.prefetch_count
+    )
+
+
+@pytest.mark.asyncio
+async def test_fdp_connect_with_already_connected_expect_skip(sut):
+    # Arrange
+    sut.mdq_connected = True
+    sut.mdc_connected = True
+
+    with patch(
+        f"{MODULE}.aio_pika.connect_robust",
+        new_callable=AsyncMock,
+    ) as mock_rmq, patch(
+        f"{MODULE}.aioredis.from_url",
+    ) as mock_redis:
+        # Act
+        await sut.connect()
+
+    # Assert
+    mock_rmq.assert_not_awaited()
+    mock_redis.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fdp_connect_with_force_expect_reconnect(sut):
+    # Arrange
+    sut.mdq_connected = True
+    sut.mdc_connected = True
+    mock_rmq_conn = AsyncMock()
+    mock_rmq_conn.channel.return_value = AsyncMock()
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock()
+
+    with patch(
+        f"{MODULE}.aio_pika.connect_robust",
+        new_callable=AsyncMock,
+        return_value=mock_rmq_conn,
+    ), patch(
+        f"{MODULE}.aioredis.from_url",
+        return_value=mock_redis,
+    ):
+        # Act
+        await sut.connect(force=True)
+
+    # Assert
+    assert sut.mdq_connected is True
+    assert sut.mdc_connected is True
+
+
+@pytest.mark.asyncio
+async def test_fdp_connect_with_rmq_failure_expect_raises(sut):
+    # Arrange
+    with patch(
+        f"{MODULE}.aio_pika.connect_robust",
+        new_callable=AsyncMock,
+        side_effect=ConnectionError("rmq down"),
+    ):
+        # Act / Assert
+        with pytest.raises(ConnectionError, match="rmq down"):
+            await sut.connect()
+
+    assert sut.mdq_connected is False
+
+
+@pytest.mark.asyncio
+async def test_fdp_connect_with_redis_failure_expect_rmq_cleaned(sut):
+    # Arrange
+    mock_rmq_conn = AsyncMock()
+    mock_rmq_channel = AsyncMock()
+    mock_rmq_conn.channel.return_value = mock_rmq_channel
+    mock_redis = MagicMock()
+    mock_redis.ping = AsyncMock(
+        side_effect=ConnectionError("redis down")
+    )
+
+    with patch(
+        f"{MODULE}.aio_pika.connect_robust",
+        new_callable=AsyncMock,
+        return_value=mock_rmq_conn,
+    ), patch(
+        f"{MODULE}.aioredis.from_url",
+        return_value=mock_redis,
+    ):
+        # Act / Assert
+        with pytest.raises(ConnectionError, match="redis down"):
+            await sut.connect()
+
+    # RabbitMQ cleaned up on Redis failure
+    mock_rmq_channel.close.assert_awaited_once()
+    mock_rmq_conn.close.assert_awaited_once()
+    assert sut.mdc_connected is False
+
+
+# ── _process_message ────────────────────────────────────────────────
+
+
+def _make_message(body_dict):
+    """Helper to build a mock AbstractIncomingMessage."""
+    msg = MagicMock(spec=AbstractIncomingMessage)
+    msg.body = json.dumps(body_dict).encode()
+    msg.delivery_tag = 42
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=None)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    msg.process.return_value = ctx
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_fdp_process_msg_with_no_results_expect_processed(
+    sut, mock_analyzer_class
+):
+    # Arrange
+    article = {"title": "Stocks Rally", "ticker": "AAPL"}
+    msg = _make_message(article)
+    analyzer = mock_analyzer_class.return_value
+    analyzer.analyze_data.return_value = None
+    sut.analyzer = analyzer
+
+    # Act
+    await sut._process_message(msg)
+
+    # Assert — dict passed directly (no WebSocketMessageSerde)
+    analyzer.analyze_data.assert_awaited_once_with(article)
+    assert sut.processed == 1
+    assert sut.published == 0
+
+
+@pytest.mark.asyncio
+async def test_fdp_process_msg_with_results_expect_published(
+    sut, mock_analyzer_class
+):
+    # Arrange
+    article = {"title": "Stocks Rally", "ticker": "AAPL"}
+    msg = _make_message(article)
+    result = MarketDataAnalyzerResult(
+        data={"sentiment": "positive"},
+        cache_key="ck",
+        cache_ttl=60,
+        publish_key="pk",
+    )
+    analyzer = mock_analyzer_class.return_value
+    analyzer.analyze_data.return_value = [result]
+    sut.analyzer = analyzer
+
+    with patch.object(sut, "_cache_result", new_callable=AsyncMock) as mock_cache:
+        # Act
+        await sut._process_message(msg)
+
+    # Assert
+    assert sut.processed == 1
+    assert sut.published == 1
+    mock_cache.assert_awaited_once_with(result)
+
+
+@pytest.mark.asyncio
+async def test_fdp_process_msg_with_multiple_results_expect_all_cached(
+    sut, mock_analyzer_class
+):
+    # Arrange
+    article = {"title": "Breaking News", "ticker": "TSLA"}
+    msg = _make_message(article)
+    results = [
+        MarketDataAnalyzerResult(data={"x": 1}, cache_key="ck1", cache_ttl=30, publish_key="pk1"),
+        MarketDataAnalyzerResult(data={"x": 2}, cache_key="ck2", cache_ttl=30, publish_key="pk2"),
+    ]
+    analyzer = mock_analyzer_class.return_value
+    analyzer.analyze_data.return_value = results
+    sut.analyzer = analyzer
+
+    with patch.object(sut, "_cache_result", new_callable=AsyncMock) as mock_cache:
+        # Act
+        await sut._process_message(msg)
+
+    # Assert
+    assert sut.processed == 1
+    assert sut.published == 2
+    assert mock_cache.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fdp_process_msg_with_analysis_error_expect_counted(
+    sut, mock_analyzer_class
+):
+    # Arrange
+    msg = _make_message({"title": "Bad News"})
+    analyzer = mock_analyzer_class.return_value
+    analyzer.analyze_data.side_effect = DataAnalysisException("bad")
+    sut.analyzer = analyzer
+
+    # Act
+    await sut._process_message(msg)
+
+    # Assert
+    assert sut.processing_error == 1
+    assert sut.processed == 0
+
+
+@pytest.mark.asyncio
+async def test_fdp_process_msg_with_bad_json_expect_decode_error(sut):
+    # Arrange
+    msg = MagicMock(spec=AbstractIncomingMessage)
+    msg.body = b"not json"
+    msg.delivery_tag = 1
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=None)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    msg.process.return_value = ctx
+
+    # Act
+    await sut._process_message(msg)
+
+    # Assert
+    assert sut.decoding_error == 1
+
+
+@pytest.mark.asyncio
+async def test_fdp_process_msg_with_unhandled_error_expect_counted(
+    sut, mock_analyzer_class
+):
+    # Arrange
+    msg = _make_message({"title": "Article"})
+    analyzer = mock_analyzer_class.return_value
+    analyzer.analyze_data.side_effect = RuntimeError("boom")
+    sut.analyzer = analyzer
+
+    # Act
+    await sut._process_message(msg)
+
+    # Assert
+    assert sut.error == 1
+
+
+@pytest.mark.asyncio
+async def test_fdp_process_msg_with_empty_results_expect_no_publish(
+    sut, mock_analyzer_class
+):
+    # Arrange — analyzer returns empty list (throttled)
+    msg = _make_message({"title": "Throttled"})
+    analyzer = mock_analyzer_class.return_value
+    analyzer.analyze_data.return_value = []
+    sut.analyzer = analyzer
+
+    with patch.object(sut, "_cache_result", new_callable=AsyncMock) as mock_cache:
+        # Act
+        await sut._process_message(msg)
+
+    # Assert
+    assert sut.processed == 1
+    assert sut.published == 0
+    mock_cache.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [
+    b"",
+    b"{broken",
+    b"[1,2,3",
+])
+async def test_fdp_process_msg_with_malformed_body_expect_decode_error(sut, body):
+    # Arrange
+    msg = MagicMock(spec=AbstractIncomingMessage)
+    msg.body = body
+    msg.delivery_tag = 99
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=None)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    msg.process.return_value = ctx
+
+    # Act
+    await sut._process_message(msg)
+
+    # Assert
+    assert sut.decoding_error == 1
+
+
+# ── _callback ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fdp_callback_with_message_expect_task_tracked(sut):
+    # Arrange
+    msg = _make_message({"title": "News"})
+    mock_task = MagicMock(spec=asyncio.Task)
+    done_cb = None
+
+    def capture_cb(cb):
+        nonlocal done_cb
+        done_cb = cb
+
+    mock_task.add_done_callback.side_effect = capture_cb
+
+    with patch("asyncio.create_task", return_value=mock_task):
+        # Act
+        await sut._callback(msg)
+
+    # Assert
+    assert mock_task in sut.processing_tasks
+    # Simulate task completion via done callback
+    done_cb(mock_task)
+    assert mock_task not in sut.processing_tasks
+
+
+# ── _cache_result ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fdp_cache_result_with_key_and_ttl_expect_setex(sut):
+    # Arrange
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    mock_redis = MagicMock()
+    mock_redis.pipeline.return_value = pipe
+    sut.redis_client = mock_redis
+    result = MarketDataAnalyzerResult(
+        data={"sentiment": "positive"}, cache_key="ck", cache_ttl=60, publish_key="pk"
+    )
+
+    # Act
+    await sut._cache_result(result)
+
+    # Assert
+    pipe.setex.assert_called_once_with(
+        "ck", 60, json.dumps({"sentiment": "positive"})
+    )
+    pipe.publish.assert_called_once_with(
+        "pk", json.dumps({"sentiment": "positive"})
+    )
+    pipe.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdp_cache_result_with_zero_ttl_expect_set(sut):
+    # Arrange
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    mock_redis = MagicMock()
+    mock_redis.pipeline.return_value = pipe
+    sut.redis_client = mock_redis
+    result = MarketDataAnalyzerResult(
+        data={"a": 1}, cache_key="ck", cache_ttl=0
+    )
+
+    # Act
+    await sut._cache_result(result)
+
+    # Assert
+    pipe.set.assert_called_once_with("ck", json.dumps({"a": 1}))
+    pipe.setex.assert_not_called()
+    pipe.publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fdp_cache_result_with_no_key_expect_no_cache(sut):
+    # Arrange
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    mock_redis = MagicMock()
+    mock_redis.pipeline.return_value = pipe
+    sut.redis_client = mock_redis
+    result = MarketDataAnalyzerResult(
+        data={"a": 1}, publish_key="pk"
+    )
+
+    # Act
+    await sut._cache_result(result)
+
+    # Assert
+    pipe.set.assert_not_called()
+    pipe.setex.assert_not_called()
+    pipe.publish.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fdp_cache_result_with_no_publish_key_expect_no_publish(sut):
+    # Arrange
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    mock_redis = MagicMock()
+    mock_redis.pipeline.return_value = pipe
+    sut.redis_client = mock_redis
+    result = MarketDataAnalyzerResult(
+        data={"a": 1}, cache_key="ck", cache_ttl=30
+    )
+
+    # Act
+    await sut._cache_result(result)
+
+    # Assert
+    pipe.setex.assert_called_once()
+    pipe.publish.assert_not_called()
+    pipe.execute.assert_awaited_once()
+
+
+# ── start ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fdp_start_with_connected_expect_consuming(
+    sut, mock_analyzer_class
+):
+    # Arrange
+    sut.mdq_connected = True
+    sut.mdc_connected = True
+    mock_queue = AsyncMock()
+    sut.rmq_channel = AsyncMock()
+    sut.rmq_channel.get_queue.return_value = mock_queue
+
+    async def fake_consume(cb, no_ack):
+        pass
+
+    mock_queue.consume = AsyncMock(side_effect=fake_consume)
+
+    call_count = 0
+
+    async def fake_sleep(_):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 1:
+            sut.running = False
+
+    with patch(
+        "asyncio.sleep", new_callable=AsyncMock, side_effect=fake_sleep
+    ), patch.object(
+        sut, "stop", new_callable=AsyncMock
+    ) as mock_stop:
+        # Act
+        await sut.start()
+
+    # Assert
+    assert mock_analyzer_class.return_value.rehydrate.awaited
+    mock_queue.consume.assert_awaited_once()
+    mock_stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdp_start_with_connect_retry_expect_retries(sut):
+    # Arrange
+    call_count = 0
+
+    async def connect_side_effect(force=False):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise ConnectionError("fail")
+        sut.mdq_connected = True
+        sut.mdc_connected = True
+
+    mock_queue = AsyncMock()
+    sut.rmq_channel = AsyncMock()
+    sut.rmq_channel.get_queue.return_value = mock_queue
+
+    async def stop_loop(_):
+        sut.running = False
+
+    with patch.object(
+        sut, "connect", new_callable=AsyncMock,
+        side_effect=connect_side_effect,
+    ), patch.object(
+        sut, "stop", new_callable=AsyncMock,
+    ), patch(
+        "asyncio.sleep", new_callable=AsyncMock,
+        side_effect=stop_loop,
+    ):
+        # Act
+        await sut.start()
+
+    # Assert — connected after retries
+    assert call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_fdp_start_with_cancelled_expect_stop_called(
+    sut, mock_analyzer_class
+):
+    # Arrange
+    sut.mdq_connected = True
+    sut.mdc_connected = True
+    mock_queue = AsyncMock()
+    sut.rmq_channel = AsyncMock()
+    sut.rmq_channel.get_queue.return_value = mock_queue
+
+    async def raise_cancel(_):
+        raise asyncio.CancelledError()
+
+    with patch(
+        "asyncio.sleep", new_callable=AsyncMock,
+        side_effect=raise_cancel,
+    ), patch.object(
+        sut, "stop", new_callable=AsyncMock,
+    ) as mock_stop:
+        # Act
+        await sut.start()
+
+    # Assert
+    mock_stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdp_start_with_max_retries_expect_raises(sut):
+    # Arrange
+    async def always_fail(force=False):
+        raise ConnectionError("fail")
+
+    with patch.object(
+        sut, "connect", new_callable=AsyncMock,
+        side_effect=always_fail,
+    ), patch(
+        "asyncio.sleep", new_callable=AsyncMock,
+    ):
+        # Act / Assert
+        with pytest.raises(ConnectionError):
+            await sut.start()
+
+
+# ── stop ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fdp_stop_with_active_conns_expect_all_closed(sut):
+    # Arrange
+    sut.rmq_channel = AsyncMock()
+    sut.rmq_connection = AsyncMock()
+    sut.redis_client = AsyncMock()
+    sut.running = True
+
+    # Act
+    await sut.stop()
+
+    # Assert
+    assert sut.running is False
+    sut.rmq_channel.close.assert_awaited_once()
+    sut.rmq_connection.close.assert_awaited_once()
+    sut.redis_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdp_stop_with_pending_tasks_expect_gathered(sut):
+    # Arrange
+    task = AsyncMock(spec=asyncio.Task)
+    sut.processing_tasks.add(task)
+    sut.rmq_channel = AsyncMock()
+    sut.rmq_connection = AsyncMock()
+    sut.redis_client = AsyncMock()
+
+    with patch(
+        "asyncio.gather", new_callable=AsyncMock
+    ) as mock_gather:
+        # Act
+        await sut.stop()
+
+    # Assert
+    mock_gather.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdp_stop_with_no_conns_expect_no_errors(sut):
+    # Arrange — all connection attrs are None (default)
+
+    # Act
+    await sut.stop()
+
+    # Assert
+    assert sut.running is False
+
+
+# ── concurrency ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fdp_semaphore_exhaustion_expect_messages_queued(sut):
+    # Arrange — set semaphore to 2 and submit 5 concurrent tasks
+    sut.semaphore = asyncio.Semaphore(2)
+    sut.running = True
+
+    async def slow_analyze(data):
+        return []
+
+    sut.analyzer = MagicMock()
+    sut.analyzer.analyze_data = AsyncMock(side_effect=slow_analyze)
+
+    messages = []
+    for i in range(5):
+        msg = AsyncMock(spec=AbstractIncomingMessage)
+        msg.body = json.dumps({"title": f"Article {i}", "ticker": f"SYM{i}"}).encode()
+        messages.append(msg)
+
+    # Act — process all messages via _callback
+    for msg in messages:
+        await sut._callback(msg)
+
+    # Wait for all tasks to complete
+    if sut.processing_tasks:
+        await asyncio.gather(*sut.processing_tasks, return_exceptions=True)
+
+    # Assert — all 5 messages processed despite semaphore limit of 2
+    assert sut.analyzer.analyze_data.call_count == 5


### PR DESCRIPTION
Closes #16

## Summary

Implements `FinlightDataProcessor` — a RabbitMQ consumer that processes Finlight news articles and caches results to Redis, mirroring the `MassiveDataProcessor` pattern.

## TDD Process

Per team standards — **test commit first, awaiting CI red phase before implementation commit is added:**

- **Commit 1** (`023e9f5`): 26 unit tests — CI expected to fail (red phase ✅)
- **Commit 2**: Implementation — to be added after test commit is reviewed and CI confirms failure

## Test coverage (26 tests)

| Section | Count |
|---|---|
| `__init__` | 4 |
| `connect` | 5 |
| `_process_message` | 7 |
| `_callback` | 1 |
| `_cache_result` | 4 |
| `start` | 4 |
| `stop` | 3 |
| concurrency | 1 |

**FDP-specific invariants enforced:**
- No `massive_api_key` parameter
- OTel counters use `fdp.` prefix
- Messages deserialized as raw JSON dicts — no `WebSocketMessageSerde`

## References

- `MassiveDataProcessor` — pattern being mirrored
- `FinlightDataQueues` — upstream queue producer (PR #21)
- Unit test standards: *Unit Testing Principles, Practices, and Patterns* (Manning)