### PR TITLE
docs: add FDL and FDP to architecture docs

### DIFF
--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -9,6 +9,7 @@ skinparam ArrowThickness 2
 title Kuhl Haus Market Data Platform - Component Architecture
 
 cloud "Massive.com WebSocket API" as Massive #FFEEEE
+cloud "Finlight News API" as Finlight #EEF4EE
 
 package "Control Plane" #EEEEEE {
     component "Service Control Plane (SCP)" as SCP #7ED321
@@ -22,6 +23,11 @@ package "Data Plane" #E8F4F8 {
         component "QueueNameResolver" as Resolver
     }
 
+    package "Finlight Data Listener (FDL)" #DDDDDD {
+        component "FinlightDataListener" as FDListener
+        component "FinlightDataQueues" as FDQueues
+    }
+
     queue "Market Data Queues (MDQ)" as MDQ #D0021B
 
     package "Market Data Processor (MDP)" #DDDDDD {
@@ -31,6 +37,10 @@ package "Data Plane" #E8F4F8 {
         component "LeaderboardAnalyzer" as Leaderboard
         component "TopTradesAnalyzer" as TopTrades
         component "TopStocksAnalyzer" as TopStocks
+    }
+
+    package "Finlight Data Processor (FDP)" #DDDDDD {
+        component "FinlightDataProcessor" as FDProcessor
     }
 
     database "Market Data Cache (MDC)" as MDC #F5A623
@@ -59,7 +69,12 @@ Listener --> Resolver : route by type
 Resolver --> Queues : publish
 Queues -[#orange,thickness=3]-> MDQ : RabbitMQ (TTL: 5s)
 
+Finlight -[#green,thickness=3]-> FDListener : WebSocket stream
+FDListener --> FDQueues : handle_message
+FDQueues -[#orange,thickness=3]-> MDQ : RabbitMQ (news queue)
+
 MDQ -[#orange,thickness=3]-> Processor : consume (prefetch: 100)
+MDQ -[#orange,thickness=3]-> FDProcessor : consume (news queue)
 Processor --> Router : analyze
 Router --> Leaderboard : aggregate events
 Router --> TopTrades : trade events
@@ -67,6 +82,7 @@ Router --> TopStocks : legacy path
 Scanner --> Leaderboard : scan leaderboards
 Scanner --> TopTrades : scan trades
 Processor -[#blue,thickness=3]-> MDC : cache + pub/sub
+FDProcessor -[#blue,thickness=3]-> MDC : cache + pub/sub
 
 MDC -[#blue,thickness=3]-> Widget : Redis pub/sub
 Widget --> CacheClient : load snapshots
@@ -76,10 +92,14 @@ SCP .[#purple,dashed].> Widget : manage/monitor
 SCP -[#green,thickness=3]-> Clients : SPA + auth token
 
 Listener .down.> OTel : traces/metrics
+FDListener .down.> OTel : traces/metrics
 Processor .down.> OTel : traces/metrics
+FDProcessor .down.> OTel : traces/metrics
 Widget .down.> OTel : traces/metrics
 Listener .down.> Logging : JSON logs
+FDListener .down.> Logging : JSON logs
 Processor .down.> Logging : JSON logs
+FDProcessor .down.> Logging : JSON logs
 Widget .down.> Logging : JSON logs
 
 Listener --> Serde : serialize

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -16,6 +16,12 @@ Components Summary
 Data Plane Components
 ----------------------
 
+**Finlight Data Listener (FDL)**
+  WebSocket client connecting to the Finlight news API, routing articles to the RabbitMQ news queue with minimal processing overhead.
+
+**Finlight Data Processor (FDP)**
+  Async RabbitMQ consumer processing Finlight news articles through pluggable analyzers and writing results to Redis.
+
 **Market Data Listener (MDL)**
   WebSocket client connecting to Massive.com, routing events to appropriate queues with minimal processing overhead.
 
@@ -63,6 +69,32 @@ Component Descriptions
 
 See the :doc:`full-page diagram <architecture-diagram>` for a full-page view.
 
+
+Finlight Data Listener (FDL)
+-----------------------------
+
+The FDL connects to the Finlight news WebSocket API and routes incoming articles to the RabbitMQ ``news`` queue via ``FinlightDataQueues``. It performs minimal processing — the listener delegates each article directly to ``FinlightDataQueues.handle_message``, which serializes and publishes it. Auto-reconnect is handled by ``FinlightDataListener``.
+
+FDL runs as a container and scales independently of other components. FDL should not be accessible outside the data plane local network.
+
+Code Libraries
+~~~~~~~~~~~~~~
+
+- **FinlightDataListener** (`components/finlight_data_listener.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.components.html#module-kuhl_haus.mdp.components.finlight_data_listener>`_) - WebSocket client wrapper for the Finlight news API with persistent connection management and auto-reconnect logic
+- **FinlightDataQueues** (`components/finlight_data_queues.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.components.html#module-kuhl_haus.mdp.components.finlight_data_queues>`_) - Single-channel RabbitMQ publisher serializing Finlight article objects to the ``news`` queue
+- **FinlightDataQueue** enum (`enum/finlight_data_queue.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.enum.html#module-kuhl_haus.mdp.enum.finlight_data_queue>`_) - Queue name constant for routing (NEWS = ``"news"``)
+
+Finlight Data Processor (FDP)
+-------------------------------
+
+The FDP consumes news articles from the RabbitMQ ``news`` queue and delegates processing to a pluggable analyzer. Like the MDP, it uses semaphore-based concurrency control and writes results to Redis. The FDP is designed for a lower-throughput news feed rather than high-velocity tick data, so it runs as a single async processor rather than using ``ProcessManager`` parallelism.
+
+FDP runs as a container and scales independently of other components. FDP should not be accessible outside the data plane local network.
+
+Code Libraries
+~~~~~~~~~~~~~~
+
+- **FinlightDataProcessor** (`components/finlight_data_processor.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.components.html#module-kuhl_haus.mdp.components.finlight_data_processor>`_) - Async RabbitMQ consumer with semaphore-based concurrency. Deserializes JSON article payloads directly (no WebSocketMessageSerde) and delegates to pluggable analyzers.
 
 Market Data Listener (MDL)
 ---------------------------


### PR DESCRIPTION
Adds Finlight Data Listener (FDL) and Finlight Data Processor (FDP) to both architecture documents.

**architecture.puml:**
- Finlight cloud node
- FDL package (FinlightDataListener + FinlightDataQueues)
- FDP package (FinlightDataProcessor)
- Finlight → FDL → MDQ → FDP → MDC flow
- OTel/logging wiring for FDL and FDP

**architecture.rst:**
- FDL and FDP added to the Data Plane Components summary
- Full component description sections for FDL and FDP with code library references

Co-Authored-By: Tom Pounders <git@oldschool.engineer>