### PR TITLE
docs: add Configuration Reference page

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,233 @@
+Configuration Reference
+=======================
+
+All MDP server containers are configured exclusively via environment variables.
+No configuration files are required at runtime.
+
+.. contents:: Servers
+   :local:
+   :depth: 1
+
+----
+
+Common Variables
+----------------
+
+These variables are supported by all servers.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Variable
+     - Default
+     - Description
+   * - ``LOG_LEVEL``
+     - ``INFO``
+     - Logging level: ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``
+   * - ``SERVER_IP``
+     - ``0.0.0.0``
+     - IP address to bind the HTTP server
+   * - ``SERVER_PORT``
+     - *(server-specific)*
+     - TCP port for the HTTP server (see per-server defaults below)
+   * - ``RABBITMQ_URL``
+     - ``amqp://mdq:mdq@localhost:5672/``
+     - RabbitMQ connection URL (AMQP)
+   * - ``REDIS_URL``
+     - ``redis://mdc:mdc@localhost:6379/0``
+     - Redis connection URL
+   * - ``MDQ_PUBLISHER_CONFIRMS``
+     - ``true``
+     - Enable RabbitMQ publisher confirms (``true`` / ``false``)
+   * - ``MARKET_DATA_MESSAGE_TTL``
+     - ``5000``
+     - RabbitMQ message TTL in milliseconds
+   * - ``CONTAINER_IMAGE``
+     - ``Unknown``
+     - Image name injected at build time (informational)
+   * - ``IMAGE_VERSION``
+     - ``Unknown``
+     - Image version injected at build time (informational)
+
+----
+
+Finlight Data Listener (FDL)
+-----------------------------
+
+**Default port:** 4200
+
+The FDL connects to the Finlight news WebSocket API and routes articles to the
+RabbitMQ ``news`` queue.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Variable
+     - Default
+     - Description
+   * - ``FINLIGHT_API_KEY``
+     - *(required)*
+     - Finlight API key for WebSocket authentication
+   * - ``FINLIGHT_QUERY``
+     - *(none)*
+     - Full-text query filter for incoming articles (e.g. ``"earnings catalyst"``)
+   * - ``FINLIGHT_TICKERS``
+     - *(none)*
+     - JSON array of ticker symbols to filter (e.g. ``'["AAPL","TSLA"]'``)
+   * - ``FINLIGHT_SOURCES``
+     - *(none)*
+     - JSON array of news source domains to filter (e.g. ``'["reuters.com"]'``)
+   * - ``FINLIGHT_LANGUAGE``
+     - *(none)*
+     - ISO 639-1 language code to filter (e.g. ``en``)
+   * - ``FINLIGHT_RAW``
+     - ``false``
+     - Subscribe to raw (unprocessed) article feed instead of enriched feed
+   * - ``FINLIGHT_MAX_RECONNECTS``
+     - ``5``
+     - Maximum WebSocket reconnection attempts before giving up
+   * - ``MARKET_DATA_LISTENER_AUTO_START_ENABLED``
+     - ``false``
+     - Automatically connect to Finlight on startup. When ``false``, use the ``/start`` endpoint to connect manually.
+
+----
+
+Finlight Data Processor (FDP)
+-------------------------------
+
+**Default port:** 4202
+
+The FDP consumes articles from the RabbitMQ ``news`` queue and processes them
+through a pluggable analyzer, writing results to Redis.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Variable
+     - Default
+     - Description
+   * - ``FDP_QUEUE_NAME``
+     - ``news``
+     - RabbitMQ queue to consume from
+   * - ``PREFETCH_COUNT``
+     - ``100``
+     - RabbitMQ prefetch count (messages delivered before ACK required)
+   * - ``MAX_CONCURRENCY``
+     - ``500``
+     - Maximum concurrent async processing tasks (semaphore limit)
+
+----
+
+Market Data Listener (MDL)
+---------------------------
+
+**Default port:** 4200
+
+The MDL connects to the Massive.com WebSocket API and routes tick data events
+to per-type RabbitMQ queues.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Variable
+     - Default
+     - Description
+   * - ``MASSIVE_FEED``
+     - ``RealTime``
+     - Massive.com feed type: ``RealTime`` or ``Delayed``
+   * - ``MASSIVE_MARKET``
+     - ``Stocks``
+     - Massive.com market: ``Stocks``, ``Options``, or ``Indices``
+   * - ``MASSIVE_SUBSCRIPTIONS``
+     - ``["A.*","T.*","Q.*","LULD.*"]``
+     - JSON array of WebSocket subscription patterns
+   * - ``MASSIVE_RAW``
+     - ``false``
+     - Subscribe to raw feed instead of typed events
+   * - ``MASSIVE_VERBOSE``
+     - ``false``
+     - Enable verbose Massive SDK logging
+   * - ``MASSIVE_SECURE``
+     - ``true``
+     - Use TLS for Massive.com WebSocket connection
+   * - ``MASSIVE_MAX_RECONNECTS``
+     - ``5``
+     - Maximum WebSocket reconnection attempts before giving up
+   * - ``MARKET_DATA_LISTENER_AUTO_START_ENABLED``
+     - ``false``
+     - Automatically connect to Massive.com on startup. When ``false``, use the ``/start`` endpoint.
+
+----
+
+Market Data Processor (MDP)
+----------------------------
+
+**Default port:** 4201
+
+The MDP runs parallel ``MassiveDataProcessor`` workers consuming from
+multiple RabbitMQ queues and writing results to Redis.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Variable
+     - Default
+     - Description
+   * - ``PARALLELISM``
+     - ``10``
+     - Number of parallel processor workers per queue type
+   * - ``PREFETCH_COUNT``
+     - ``10``
+     - RabbitMQ prefetch count per worker
+   * - ``MAX_CONCURRENCY``
+     - ``100``
+     - Maximum concurrent async tasks per worker (semaphore limit)
+
+----
+
+Leaderboard Analyzer (LBA)
+---------------------------
+
+**Default port:** 4201
+
+The LBA subscribes to Redis pub/sub channels and runs leaderboard and trade
+analyzers sequentially.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Variable
+     - Default
+     - Description
+   * - ``AUTH_ENABLED``
+     - ``false``
+     - Enable API key authentication for LBA endpoints
+   * - ``AUTH_API_KEY``
+     - *(none)*
+     - API key required when ``AUTH_ENABLED=true``
+
+----
+
+Widget Data Service (WDS)
+--------------------------
+
+**Default port:** 4200
+
+The WDS bridges Redis pub/sub to client WebSocket connections with fan-out.
+
+No WDS-specific environment variables beyond the common set above.
+
+----
+
+.. note::
+
+   Filter settings for FDL (``FINLIGHT_QUERY``, ``FINLIGHT_TICKERS``,
+   ``FINLIGHT_SOURCES``, ``FINLIGHT_LANGUAGE``) can also be updated at
+   runtime via the FDL server's REST API (``POST /query``, ``POST /tickers``,
+   etc.) without restarting the container.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -55,7 +55,7 @@ These variables are supported by all servers.
 Finlight Data Listener (FDL)
 -----------------------------
 
-**Default port:** 4200
+**Default port:** 4203
 
 The FDL connects to the Finlight news WebSocket API and routes articles to the
 RabbitMQ ``news`` queue.
@@ -97,7 +97,7 @@ RabbitMQ ``news`` queue.
 Finlight Data Processor (FDP)
 -------------------------------
 
-**Default port:** 4202
+**Default port:** 4204
 
 The FDP consumes articles from the RabbitMQ ``news`` queue and processes them
 through a pluggable analyzer, writing results to Redis.
@@ -193,7 +193,7 @@ multiple RabbitMQ queues and writing results to Redis.
 Leaderboard Analyzer (LBA)
 ---------------------------
 
-**Default port:** 4201
+**Default port:** 4210
 
 The LBA subscribes to Redis pub/sub channels and runs leaderboard and trade
 analyzers sequentially.
@@ -217,7 +217,7 @@ analyzers sequentially.
 Widget Data Service (WDS)
 --------------------------
 
-**Default port:** 4200
+**Default port:** 4202
 
 The WDS bridges Redis pub/sub to client WebSocket connections with fan-out.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Contents
    Overview <readme>
    Architecture <architecture>
    Component Architecture <architecture-diagram>
+   Configuration Reference <configuration>
    Module Reference <mdp/modules>
    Contributions & Help <contributing>
    Security Policy <security>


### PR DESCRIPTION
Adds `docs/configuration.rst` — a full Configuration Reference documenting all environment variables for all six servers (FDL, FDP, MDL, MDP, LBA, WDS).

Structure:
- Common variables (once at top — LOG_LEVEL, RABBITMQ_URL, REDIS_URL, etc.)
- Per-server sections with default port, description, and variable table
- Runtime API note for FDL filter variables

Also adds it to the toctree in `index.rst`.

Co-Authored-By: Tom Pounders <git@oldschool.engineer>