### PR TITLE
docs: remove contents directive from configuration.rst

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,9 +4,6 @@ Configuration Reference
 All MDP server containers are configured exclusively via environment variables.
 No configuration files are required at runtime.
 
-.. contents:: Servers
-   :local:
-   :depth: 1
 
 ----
 


### PR DESCRIPTION
Removes the `.. contents::` directive — Furo handles sidebar navigation natively and the directive causes a Sphinx warning.\n\nCo-Authored-By: Tom Pounders <git@oldschool.engineer>