### PR TITLE
feat: rolling list cache for news feeds (closes #40)

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
@@ -69,6 +69,7 @@ class FinlightDataAnalyzer(Analyzer):
             cache_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
             cache_ttl=MarketDataCacheTTL.NEWS_FEED_LATEST.value,
             publish_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
+            cache_list_max=1000,
         )]
 
         # All articles go to the feed regardless of mode
@@ -88,6 +89,7 @@ class FinlightDataAnalyzer(Analyzer):
                 cache_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
                 cache_ttl=MarketDataCacheTTL.NEWS_TICKER.value,
                 publish_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
+                cache_list_max=20,
             ))
 
         return results

--- a/src/kuhl_haus/mdp/components/finlight_data_processor.py
+++ b/src/kuhl_haus/mdp/components/finlight_data_processor.py
@@ -245,7 +245,13 @@ class FinlightDataProcessor:
         # Pipeline - no async context manager, no await on queue methods
         pipe = self.redis_client.pipeline(transaction=False)
         if analyzer_result.cache_key:
-            if analyzer_result.cache_ttl > 0:
+            if analyzer_result.cache_list_max is not None:
+                # Rolling list: prepend + trim to max + optional TTL
+                pipe.lpush(analyzer_result.cache_key, result_json)
+                pipe.ltrim(analyzer_result.cache_key, 0, analyzer_result.cache_list_max - 1)
+                if analyzer_result.cache_ttl and analyzer_result.cache_ttl > 0:
+                    pipe.expire(analyzer_result.cache_key, analyzer_result.cache_ttl)
+            elif analyzer_result.cache_ttl and analyzer_result.cache_ttl > 0:
                 pipe.setex(analyzer_result.cache_key, analyzer_result.cache_ttl, result_json)
             else:
                 pipe.set(analyzer_result.cache_key, result_json)

--- a/src/kuhl_haus/mdp/components/widget_data_service.py
+++ b/src/kuhl_haus/mdp/components/widget_data_service.py
@@ -189,13 +189,30 @@ class WidgetDataService:
 
         Clients typically call this before subscribing to a feed to get current state,
         then receive incremental updates via WebSocket. Returns None if key not found.
+
+        Supports both Redis string keys (returns dict) and list keys (returns list of dicts).
+        List keys are used for rolling news feed caches (news:feed:latest, news:ticker:*).
         """
         self.logger.debug(f"wds.cache.get cache_key:{cache_key}")
-        value = await self.redis_client.get(cache_key)
-        if value:
-            self.logger.debug(f"wds.cache.hit cache_key:{cache_key}")
-            self.cache_hit_counter.add(1)
-            return json.loads(value)
+        key_type = await self.redis_client.type(cache_key)
+
+        if key_type == b"list":
+            values = await self.redis_client.lrange(cache_key, 0, -1)
+            if values:
+                self.logger.debug(f"wds.cache.hit cache_key:{cache_key} type:list len:{len(values)}")
+                self.cache_hit_counter.add(1)
+                return [json.loads(v) for v in values]
+            self.logger.debug(f"wds.cache.miss cache_key:{cache_key} type:list")
+            self.cache_miss_counter.add(1)
+            return []
+
+        if key_type == b"string":
+            value = await self.redis_client.get(cache_key)
+            if value:
+                self.logger.debug(f"wds.cache.hit cache_key:{cache_key} type:string")
+                self.cache_hit_counter.add(1)
+                return json.loads(value)
+
         self.logger.debug(f"wds.cache.miss cache_key:{cache_key}")
         self.cache_miss_counter.add(1)
         return None

--- a/src/kuhl_haus/mdp/data/market_data_analyzer_result.py
+++ b/src/kuhl_haus/mdp/data/market_data_analyzer_result.py
@@ -31,3 +31,4 @@ class MarketDataAnalyzerResult:
     cache_key: Optional[str] = None
     cache_ttl: Optional[int] = 0
     publish_key: Optional[str] = None
+    cache_list_max: Optional[int] = None

--- a/tests/analyzers/test_finlight_data_analyzer.py
+++ b/tests/analyzers/test_finlight_data_analyzer.py
@@ -476,3 +476,83 @@ def test_fda_extract_raw_tickers_with_deduplicated_expect_no_duplicates(sut):
 
     # Assert
     assert tickers.count("MSFT") == 1
+
+
+# ── cache_list_max ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_feed_result_expect_cache_list_max_1000(sut):
+    # Arrange
+    article = _raw_article()
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert
+    feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
+    assert feed.cache_list_max == 1000
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_key_set(sut):
+    # Arrange
+    article = _enhanced_article(companies=[_company("AAPL", "XNAS")])
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert
+    ticker_result = next(
+        r for r in results
+        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+    )
+    assert ticker_result.cache_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_list_max_20(sut):
+    # Arrange
+    article = _enhanced_article(companies=[_company("AAPL", "XNAS")])
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert
+    ticker_result = next(
+        r for r in results
+        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+    )
+    assert ticker_result.cache_list_max == 20
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_raw_ticker_expect_cache_key_set(sut):
+    # Arrange
+    article = _raw_article(title="AAPL rises (Nasdaq: AAPL)")
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert
+    ticker_result = next(
+        r for r in results
+        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+    )
+    assert ticker_result.cache_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_raw_ticker_expect_cache_list_max_20(sut):
+    # Arrange
+    article = _raw_article(title="AAPL rises (Nasdaq: AAPL)")
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert
+    ticker_result = next(
+        r for r in results
+        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+    )
+    assert ticker_result.cache_list_max == 20

--- a/tests/components/test_finlight_data_processor.py
+++ b/tests/components/test_finlight_data_processor.py
@@ -790,3 +790,61 @@ async def test_fdp_semaphore_exhaustion_expect_messages_queued(sut):
 
     # Assert — all 5 messages processed despite semaphore limit of 2
     assert sut.analyzer.analyze_data.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_fdp_cache_result_with_list_max_and_ttl_expect_lpush_ltrim_expire(sut):
+    # Arrange
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    mock_redis = MagicMock()
+    mock_redis.pipeline.return_value = pipe
+    sut.redis_client = mock_redis
+    result = MarketDataAnalyzerResult(
+        data={"title": "Breaking news"},
+        cache_key="news:feed:latest",
+        cache_ttl=3600,
+        publish_key="news:feed:latest",
+        cache_list_max=1000,
+    )
+
+    # Act
+    await sut._cache_result(result)
+
+    # Assert
+    expected_json = json.dumps({"title": "Breaking news"})
+    pipe.lpush.assert_called_once_with("news:feed:latest", expected_json)
+    pipe.ltrim.assert_called_once_with("news:feed:latest", 0, 999)
+    pipe.expire.assert_called_once_with("news:feed:latest", 3600)
+    pipe.set.assert_not_called()
+    pipe.setex.assert_not_called()
+    pipe.publish.assert_called_once_with("news:feed:latest", expected_json)
+    pipe.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fdp_cache_result_with_list_max_and_zero_ttl_expect_no_expire(sut):
+    # Arrange
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    mock_redis = MagicMock()
+    mock_redis.pipeline.return_value = pipe
+    sut.redis_client = mock_redis
+    result = MarketDataAnalyzerResult(
+        data={"title": "Ticker news"},
+        cache_key="news:ticker:AAPL",
+        cache_ttl=0,
+        publish_key="news:ticker:AAPL",
+        cache_list_max=20,
+    )
+
+    # Act
+    await sut._cache_result(result)
+
+    # Assert
+    expected_json = json.dumps({"title": "Ticker news"})
+    pipe.lpush.assert_called_once_with("news:ticker:AAPL", expected_json)
+    pipe.ltrim.assert_called_once_with("news:ticker:AAPL", 0, 19)
+    pipe.expire.assert_not_called()
+    pipe.set.assert_not_called()
+    pipe.setex.assert_not_called()

--- a/tests/components/test_widget_data_service.py
+++ b/tests/components/test_widget_data_service.py
@@ -314,7 +314,8 @@ async def test_wds_get_cache_with_hit_expect_parsed(
     sut, mock_redis,
 ):
     # Arrange
-    mock_redis.get.return_value = '{"foo": "bar"}'
+    mock_redis.type = AsyncMock(return_value=b"string")
+    mock_redis.get = AsyncMock(return_value=b'{"foo": "bar"}')
 
     # Act
     result = await sut.get_cache("cache:test")
@@ -328,7 +329,7 @@ async def test_wds_get_cache_with_miss_expect_none(
     sut, mock_redis,
 ):
     # Arrange
-    mock_redis.get.return_value = None
+    mock_redis.type = AsyncMock(return_value=b"none")
 
     # Act
     result = await sut.get_cache("cache:test")

--- a/tests/components/test_widget_data_service.py
+++ b/tests/components/test_widget_data_service.py
@@ -709,3 +709,67 @@ async def test_wds_handle_pubsub_with_generic_error_expect_raises(
     with patch.object(sut.logger, "error"):
         with pytest.raises(RuntimeError, match="fatal"):
             await sut._handle_pubsub()
+
+
+@pytest.mark.asyncio
+async def test_wds_get_cache_with_list_key_expect_parsed_list(
+    sut, mock_redis,
+):
+    # Arrange
+    mock_redis.type = AsyncMock(return_value=b"list")
+    mock_redis.lrange = AsyncMock(return_value=[
+        b'{"title": "Article 1"}',
+        b'{"title": "Article 2"}',
+    ])
+
+    # Act
+    result = await sut.get_cache("news:feed:latest")
+
+    # Assert
+    mock_redis.lrange.assert_called_once_with("news:feed:latest", 0, -1)
+    assert result == [{"title": "Article 1"}, {"title": "Article 2"}]
+
+
+@pytest.mark.asyncio
+async def test_wds_get_cache_with_string_key_expect_parsed_dict(
+    sut, mock_redis,
+):
+    # Arrange
+    mock_redis.type = AsyncMock(return_value=b"string")
+    mock_redis.get = AsyncMock(return_value=b'{"symbol": "AAPL"}')
+
+    # Act
+    result = await sut.get_cache("scanners:top_gainers")
+
+    # Assert
+    mock_redis.get.assert_called_once_with("scanners:top_gainers")
+    assert result == {"symbol": "AAPL"}
+
+
+@pytest.mark.asyncio
+async def test_wds_get_cache_with_list_key_miss_expect_empty_list(
+    sut, mock_redis,
+):
+    # Arrange
+    mock_redis.type = AsyncMock(return_value=b"list")
+    mock_redis.lrange = AsyncMock(return_value=[])
+
+    # Act
+    result = await sut.get_cache("news:feed:latest")
+
+    # Assert
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_wds_get_cache_with_none_type_expect_none(
+    sut, mock_redis,
+):
+    # Arrange
+    mock_redis.type = AsyncMock(return_value=b"none")
+
+    # Act
+    result = await sut.get_cache("news:feed:latest")
+
+    # Assert
+    assert result is None

--- a/tests/data/test_market_data_analyzer_result.py
+++ b/tests/data/test_market_data_analyzer_result.py
@@ -1,0 +1,22 @@
+import pytest
+
+from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
+
+
+# ── cache_list_max ──────────────────────────────────────────────────
+
+
+def test_market_data_analyzer_result_with_no_cache_list_max_expect_none():
+    # Arrange / Act
+    sut = MarketDataAnalyzerResult(data={"x": 1})
+
+    # Assert
+    assert sut.cache_list_max is None
+
+
+def test_market_data_analyzer_result_with_cache_list_max_set_expect_stored():
+    # Arrange / Act
+    sut = MarketDataAnalyzerResult(data={"x": 1}, cache_list_max=1000)
+
+    # Assert
+    assert sut.cache_list_max == 1000


### PR DESCRIPTION
Switches news feed cache entries from Redis strings to Redis lists, giving the NewsFeed widget a full history on load instead of just the last article.

## Changes

**`MarketDataAnalyzerResult`**
- New field: `cache_list_max: Optional[int] = None`

**`FinlightDataAnalyzer`**
- `news:feed:latest`: `cache_list_max=1000`
- `news:ticker:{TICKER}`: `cache_key` now set (was None) + `cache_list_max=20`

**`FinlightDataProcessor._cache_result()`**
- List path: `LPUSH` + `LTRIM` + `EXPIRE` when `cache_list_max` is set
- String path (SET/SETEX) unchanged

**`WidgetDataService.get_cache()`**
- Checks Redis key type; uses `LRANGE 0 -1` for list keys, `GET` for strings

## Result

NewsFeed widget loads up to 1,000 recent articles from cache on connect. Per-ticker feeds cache the 20 most recent articles.