### PR TITLE
fix(WDS): redis type() returns str not bytes

### DIFF
--- a/src/kuhl_haus/mdp/components/widget_data_service.py
+++ b/src/kuhl_haus/mdp/components/widget_data_service.py
@@ -196,7 +196,10 @@ class WidgetDataService:
         self.logger.debug(f"wds.cache.get cache_key:{cache_key}")
         key_type = await self.redis_client.type(cache_key)
 
-        if key_type == b"list":
+        # redis-py returns str, not bytes (e.g. "list", "string", "none")
+        key_type_str = key_type.decode() if isinstance(key_type, bytes) else key_type
+
+        if key_type_str == "list":
             values = await self.redis_client.lrange(cache_key, 0, -1)
             if values:
                 self.logger.debug(f"wds.cache.hit cache_key:{cache_key} type:list len:{len(values)}")
@@ -206,7 +209,7 @@ class WidgetDataService:
             self.cache_miss_counter.add(1)
             return []
 
-        if key_type == b"string":
+        if key_type_str == "string":
             value = await self.redis_client.get(cache_key)
             if value:
                 self.logger.debug(f"wds.cache.hit cache_key:{cache_key} type:string")

--- a/tests/components/test_widget_data_service.py
+++ b/tests/components/test_widget_data_service.py
@@ -314,7 +314,7 @@ async def test_wds_get_cache_with_hit_expect_parsed(
     sut, mock_redis,
 ):
     # Arrange
-    mock_redis.type = AsyncMock(return_value=b"string")
+    mock_redis.type = AsyncMock(return_value="string")
     mock_redis.get = AsyncMock(return_value=b'{"foo": "bar"}')
 
     # Act
@@ -329,7 +329,7 @@ async def test_wds_get_cache_with_miss_expect_none(
     sut, mock_redis,
 ):
     # Arrange
-    mock_redis.type = AsyncMock(return_value=b"none")
+    mock_redis.type = AsyncMock(return_value="none")
 
     # Act
     result = await sut.get_cache("cache:test")
@@ -717,7 +717,7 @@ async def test_wds_get_cache_with_list_key_expect_parsed_list(
     sut, mock_redis,
 ):
     # Arrange
-    mock_redis.type = AsyncMock(return_value=b"list")
+    mock_redis.type = AsyncMock(return_value="list")
     mock_redis.lrange = AsyncMock(return_value=[
         b'{"title": "Article 1"}',
         b'{"title": "Article 2"}',
@@ -736,7 +736,7 @@ async def test_wds_get_cache_with_string_key_expect_parsed_dict(
     sut, mock_redis,
 ):
     # Arrange
-    mock_redis.type = AsyncMock(return_value=b"string")
+    mock_redis.type = AsyncMock(return_value="string")
     mock_redis.get = AsyncMock(return_value=b'{"symbol": "AAPL"}')
 
     # Act
@@ -752,7 +752,7 @@ async def test_wds_get_cache_with_list_key_miss_expect_empty_list(
     sut, mock_redis,
 ):
     # Arrange
-    mock_redis.type = AsyncMock(return_value=b"list")
+    mock_redis.type = AsyncMock(return_value="list")
     mock_redis.lrange = AsyncMock(return_value=[])
 
     # Act
@@ -767,7 +767,7 @@ async def test_wds_get_cache_with_none_type_expect_none(
     sut, mock_redis,
 ):
     # Arrange
-    mock_redis.type = AsyncMock(return_value=b"none")
+    mock_redis.type = AsyncMock(return_value="none")
 
     # Act
     result = await sut.get_cache("news:feed:latest")


### PR DESCRIPTION
**Root cause:** `get_cache()` compared `key_type` against `b'list'`/`b'string'` (bytes literals), but `redis.asyncio` returns plain strings from `.type()`. The condition never matched, so `lrange` was never called and the cache always appeared empty.

**Fix:** Decode bytes defensively then compare against plain strings. Test mocks corrected to return `str` (matching actual redis-py behavior) — the tests passed before because the mocks matched our wrong expectation.