### PR TITLE
refactor(MarketDataCache): replace aiohttp free float with RESTClient (closes #44)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python"
 ]
 dependencies = [
-    "aiohttp",
     "aio-pika",
     "fastapi",
     "finlight-client",

--- a/src/kuhl_haus/mdp/analyzers/leaderboard_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/leaderboard_analyzer.py
@@ -51,7 +51,6 @@ class LeaderboardAnalyzer(Analyzer):
         self.cache = MarketDataCache(
             rest_client=self.rest_client,
             redis_client=self.redis_client,
-            massive_api_key=options.massive_api_key
         )
         meter = get_meter(__name__)
         self.processed_counter = meter.create_counter(

--- a/src/kuhl_haus/mdp/analyzers/top_stocks.py
+++ b/src/kuhl_haus/mdp/analyzers/top_stocks.py
@@ -43,7 +43,6 @@ class TopStocksAnalyzer(Analyzer):
         self.cache = MarketDataCache(
             rest_client=self.rest_client,
             redis_client=self.redis_client,
-            massive_api_key=options.massive_api_key
         )
         self.cache_key = MarketDataCacheKeys.TOP_STOCKS_SCANNER.value
         self.logger = logging.getLogger(__name__)

--- a/src/kuhl_haus/mdp/analyzers/top_trades_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/top_trades_analyzer.py
@@ -58,7 +58,6 @@ class TopTradesAnalyzer(Analyzer):
         self.cache = MarketDataCache(
             rest_client=self.rest_client,
             redis_client=self.redis_client,
-            massive_api_key=options.massive_api_key
         )
         meter = get_meter(__name__)
         self.processed_counter = meter.create_counter(

--- a/src/kuhl_haus/mdp/components/market_data_cache.py
+++ b/src/kuhl_haus/mdp/components/market_data_cache.py
@@ -12,10 +12,10 @@ import time
 from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, Optional, Iterator, List
 
-import aiohttp
 import redis.asyncio as aioredis
 from redis.exceptions import LockNotOwnedError
 from massive.rest import RESTClient
+from massive.rest.models.financials import FinancialFloat
 from massive.rest.models import (
     TickerSnapshot,
     FinancialRatio,
@@ -39,15 +39,11 @@ class MarketDataCache:
     cache with appropriate TTL. Negative caching (short TTL) for missing/error
     responses prevents API hammering.
 
-    Uses aiohttp for experimental Massive API endpoints (/vX/float) not yet
-    available in the official SDK.
     """
-    def __init__(self, rest_client: RESTClient, redis_client: aioredis.Redis, massive_api_key: str):
+    def __init__(self, rest_client: RESTClient, redis_client: aioredis.Redis):
         self.logger = logging.getLogger(__name__)
         self.rest_client = rest_client
-        self.massive_api_key = massive_api_key
         self.redis_client = redis_client
-        self.http_session = None
         meter = get_meter(__name__)
         self.delete_counter = meter.create_counter(
             name="mdc.delete",
@@ -561,80 +557,24 @@ class MarketDataCache:
                 return result
 
             cache_ttl = MarketDataCacheTTL.TICKER_FREE_FLOAT.value
-
-            # NOTE: This endpoint is experimental and the interface
-            # may change.
-            # https://massive.com/docs/rest/stocks/fundamentals/float
-            url = "https://api.massive.com/stocks/vX/float"
-            params = {
-                "ticker": ticker,
-                "apiKey": self.massive_api_key
-            }
-
-            session = await self.get_http_session()
             start = time.monotonic()
             try:
-                async with session.get(
-                    url,
-                    params=params,
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ) as response:
-                    response.raise_for_status()
-                    data = await response.json()
-
-                    # Extract free_float from response
-                    if (
-                        data.get("status") == "OK"
-                        and data.get("results") is not None
-                    ):
-                        results = data["results"]
-                        if len(results) > 0:
-                            free_float = results[0].get(
-                                "free_float"
-                            )
-                        else:
-                            self.logger.debug(
-                                f"No free float data returned "
-                                f"for {ticker}"
-                            )
-                            free_float = 0
-                            cache_ttl = (
-                                MarketDataCacheTTL
-                                .NEGATIVE_CACHE_SESSION.value
-                            )
-                    else:
-                        raise Exception(
-                            f"Invalid response from Massive "
-                            f"API for {ticker}: {data}"
-                        )
-            except asyncio.TimeoutError as e:
-                self.logger.error(
-                    f"Timeout fetching free float for "
-                    f"{ticker}: {e}",
-                    stack_info=True, exc_info=True,
+                floats: List[FinancialFloat] = list(
+                    self.rest_client.list_stocks_floats(ticker=ticker)
                 )
-                free_float = 0
-                cache_ttl = (
-                    MarketDataCacheTTL
-                    .NEGATIVE_CACHE_THROTTLE.value
-                )
-                self.timeout_error_counter.add(1)
-            except aiohttp.ClientError as e:
-                self.logger.error(
-                    f"HTTP error fetching free float for "
-                    f"{ticker}: {e}",
-                    stack_info=True, exc_info=True,
-                )
-                free_float = 0
-                cache_ttl = (
-                    MarketDataCacheTTL
-                    .NEGATIVE_CACHE_THROTTLE.value
-                )
-                self.http_error_counter.add(1)
+                if floats:
+                    free_float = floats[0].free_float
+                else:
+                    self.logger.debug(
+                        f"No free float data returned for {ticker}"
+                    )
+                    free_float = 0
+                    cache_ttl = (
+                        MarketDataCacheTTL.NEGATIVE_CACHE_SESSION.value
+                    )
             except Exception as e:
                 self.logger.error(
-                    f"Error fetching free float for "
-                    f"{ticker}: {e}",
+                    f"Error fetching free float for {ticker}: {e}",
                     stack_info=True, exc_info=True,
                 )
                 self.error_counter.add(1)
@@ -645,7 +585,6 @@ class MarketDataCache:
                 f"Free float API call for {ticker} "
                 f"took {duration:.3f}s"
             )
-
             self.logger.debug(
                 f"free float {ticker}: {free_float}"
             )
@@ -664,19 +603,3 @@ class MarketDataCache:
                     f"Lock expired before release for "
                     f"free float {ticker}"
                 )
-
-    @tracer.start_as_current_span("mdc.get_http_session")
-    async def get_http_session(self) -> aiohttp.ClientSession:
-        """Lazily instantiate aiohttp session for experimental API calls."""
-        if self.http_session is None or self.http_session.closed:
-            self.http_session = aiohttp.ClientSession()
-        return self.http_session
-
-    @tracer.start_as_current_span("mdc.close")
-    async def close(self):
-        """Cleanup aiohttp session.
-
-        Called during shutdown; does not close Redis client (caller owns that).
-        """
-        if self.http_session and not self.http_session.closed:
-            await self.http_session.close()

--- a/src/kuhl_haus/mdp/components/market_data_scanner.py
+++ b/src/kuhl_haus/mdp/components/market_data_scanner.py
@@ -156,7 +156,6 @@ class MarketDataScanner:
                 self.mdc = MarketDataCache(
                     rest_client=RESTClient(api_key=self.massive_api_key),
                     redis_client=self.redis_client,
-                    massive_api_key=self.massive_api_key
                 )
                 self.mdc_connected = True
                 self.logger.debug(f"Connected to Redis: {self.redis_url}")

--- a/tests/components/test_market_data_cache.py
+++ b/tests/components/test_market_data_cache.py
@@ -926,10 +926,10 @@ async def test_mdc_get_ff_with_empty_results_expect_zero(
 
 
 @pytest.mark.asyncio
-async def test_mdc_get_ff_with_api_error_expect_zero(
+async def test_mdc_get_ff_with_api_error_expect_raise(
     sut, mock_redis, mock_rest,
 ):
-    """HTTP/client errors from RESTClient are caught and return 0 with throttle TTL."""
+    """Unexpected errors from RESTClient propagate to the caller."""
     # Arrange
     lock = _mock_lock()
     mock_redis.lock = MagicMock(return_value=lock)
@@ -938,15 +938,11 @@ async def test_mdc_get_ff_with_api_error_expect_zero(
         side_effect=Exception("HTTP 500")
     )
 
-    # Act
-    result = await sut.get_free_float("TEST")
+    # Act & Assert
+    with pytest.raises(Exception, match="HTTP 500"):
+        await sut.get_free_float("TEST")
 
-    # Assert
-    assert result == 0
-    call_args = mock_redis.setex.await_args
-    assert call_args[0][1] == (
-        MarketDataCacheTTL.NEGATIVE_CACHE_THROTTLE.value
-    )
+    mock_redis.setex.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/components/test_market_data_cache.py
+++ b/tests/components/test_market_data_cache.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
-import aiohttp
 import pytest
 from massive.rest.models import TickerSnapshot
 
@@ -51,35 +50,14 @@ def _snapshot_dict():
     }
 
 
-def _free_float_response(
-    free_float=2643494955,
-    status="OK",
-    results=None,
-):
-    """Build a Massive API free-float response dict."""
-    if results is None:
-        results = [{
-            "effective_date": "2025-11-14",
-            "free_float": free_float,
-            "free_float_percent": 79.5,
-            "ticker": "TEST",
-        }]
-    return {
-        "request_id": 1,
-        "results": results,
-        "status": status,
-    }
-
-
-def _mock_http_session(response):
-    """Return a mock aiohttp session wired to *response*."""
-    ctx = AsyncMock()
-    ctx.__aenter__ = AsyncMock(return_value=response)
-    ctx.__aexit__ = AsyncMock(return_value=None)
-    session = AsyncMock()
-    session.closed = False
-    session.get = MagicMock(return_value=ctx)
-    return session
+def _financial_float(free_float=2643494955):
+    """Build a FinancialFloat-like mock object."""
+    ff = MagicMock()
+    ff.free_float = free_float
+    ff.free_float_percent = 79.5
+    ff.effective_date = "2025-11-14"
+    ff.ticker = "TEST"
+    return ff
 
 
 # -- fixtures --------------------------------------------------------
@@ -100,7 +78,6 @@ def sut(mock_redis, mock_rest):
     return MarketDataCache(
         rest_client=mock_rest,
         redis_client=mock_redis,
-        massive_api_key="test_key",
     )
 
 
@@ -118,8 +95,6 @@ def test_mdc_init_with_defaults_expect_attrs_set(
     # Assert
     assert result.rest_client is mock_rest
     assert result.redis_client is mock_redis
-    assert result.massive_api_key == "test_key"
-    assert result.http_session is None
 
 
 # -- delete ----------------------------------------------------------
@@ -911,45 +886,36 @@ async def test_mdc_get_ff_with_cache_hit_expect_cached(
 
 @pytest.mark.asyncio
 async def test_mdc_get_ff_with_cache_miss_expect_api_call(
-    sut, mock_redis,
+    sut, mock_redis, mock_rest,
 ):
     # Arrange
     lock = _mock_lock()
     mock_redis.lock = MagicMock(return_value=lock)
     mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock()
-    resp.json = AsyncMock(
-        return_value=_free_float_response()
+    mock_rest.list_stocks_floats = MagicMock(
+        return_value=iter([_financial_float()])
     )
-    session = _mock_http_session(resp)
-    sut.http_session = session
 
     # Act
     result = await sut.get_free_float("TEST")
 
     # Assert
     assert result == 2643494955
+    mock_rest.list_stocks_floats.assert_called_once_with(ticker="TEST")
     lock.acquire.assert_awaited_once()
-    session.get.assert_called_once()
     mock_redis.setex.assert_awaited_once()
     lock.release.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_mdc_get_ff_with_empty_results_expect_zero(
-    sut, mock_redis,
+    sut, mock_redis, mock_rest,
 ):
     # Arrange
     lock = _mock_lock()
     mock_redis.lock = MagicMock(return_value=lock)
     mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock()
-    resp.json = AsyncMock(
-        return_value=_free_float_response(results=[])
-    )
-    sut.http_session = _mock_http_session(resp)
+    mock_rest.list_stocks_floats = MagicMock(return_value=iter([]))
 
     # Act
     result = await sut.get_free_float("TEST")
@@ -960,42 +926,17 @@ async def test_mdc_get_ff_with_empty_results_expect_zero(
 
 
 @pytest.mark.asyncio
-async def test_mdc_get_ff_with_error_status_expect_raise(
-    sut, mock_redis,
+async def test_mdc_get_ff_with_api_error_expect_zero(
+    sut, mock_redis, mock_rest,
 ):
+    """HTTP/client errors from RESTClient are caught and return 0 with throttle TTL."""
     # Arrange
     lock = _mock_lock()
     mock_redis.lock = MagicMock(return_value=lock)
     mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock()
-    resp.json = AsyncMock(
-        return_value=_free_float_response(status="ERROR")
+    mock_rest.list_stocks_floats = MagicMock(
+        side_effect=Exception("HTTP 500")
     )
-    sut.http_session = _mock_http_session(resp)
-
-    # Act & Assert
-    with pytest.raises(
-        Exception, match="Invalid response"
-    ):
-        await sut.get_free_float("TEST")
-
-    mock_redis.setex.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_mdc_get_ff_with_client_error_expect_zero(
-    sut, mock_redis,
-):
-    # Arrange
-    lock = _mock_lock()
-    mock_redis.lock = MagicMock(return_value=lock)
-    mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock(
-        side_effect=aiohttp.ClientError("timeout")
-    )
-    sut.http_session = _mock_http_session(resp)
 
     # Act
     result = await sut.get_free_float("TEST")
@@ -1006,50 +947,6 @@ async def test_mdc_get_ff_with_client_error_expect_zero(
     assert call_args[0][1] == (
         MarketDataCacheTTL.NEGATIVE_CACHE_THROTTLE.value
     )
-
-
-@pytest.mark.asyncio
-async def test_mdc_get_ff_with_timeout_expect_zero(
-    sut, mock_redis,
-):
-    # Arrange
-    lock = _mock_lock()
-    mock_redis.lock = MagicMock(return_value=lock)
-    mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock(
-        side_effect=asyncio.TimeoutError()
-    )
-    sut.http_session = _mock_http_session(resp)
-
-    # Act
-    result = await sut.get_free_float("TEST")
-
-    # Assert
-    assert result == 0
-    call_args = mock_redis.setex.await_args
-    assert call_args[0][1] == (
-        MarketDataCacheTTL.NEGATIVE_CACHE_THROTTLE.value
-    )
-
-
-@pytest.mark.asyncio
-async def test_mdc_get_ff_with_generic_error_expect_raise(
-    sut, mock_redis,
-):
-    # Arrange
-    lock = _mock_lock()
-    mock_redis.lock = MagicMock(return_value=lock)
-    mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock(
-        side_effect=RuntimeError("unexpected")
-    )
-    sut.http_session = _mock_http_session(resp)
-
-    # Act & Assert
-    with pytest.raises(RuntimeError, match="unexpected"):
-        await sut.get_free_float("TEST")
 
 
 @pytest.mark.asyncio
@@ -1074,18 +971,15 @@ async def test_mdc_get_ff_with_miss_double_check_hit(
 
 @pytest.mark.asyncio
 async def test_mdc_get_ff_lock_uses_correct_key_and_ttl(
-    sut, mock_redis,
+    sut, mock_redis, mock_rest,
 ):
     # Arrange
     lock = _mock_lock()
     mock_redis.lock = MagicMock(return_value=lock)
     mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock()
-    resp.json = AsyncMock(
-        return_value=_free_float_response()
+    mock_rest.list_stocks_floats = MagicMock(
+        return_value=iter([_financial_float()])
     )
-    sut.http_session = _mock_http_session(resp)
 
     # Act
     await sut.get_free_float("AAPL")
@@ -1103,18 +997,15 @@ async def test_mdc_get_ff_lock_uses_correct_key_and_ttl(
 
 @pytest.mark.asyncio
 async def test_mdc_get_ff_with_miss_expect_duration_recorded(
-    sut, mock_redis,
+    sut, mock_redis, mock_rest,
 ):
     # Arrange
     lock = _mock_lock()
     mock_redis.lock = MagicMock(return_value=lock)
     mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock()
-    resp.json = AsyncMock(
-        return_value=_free_float_response()
+    mock_rest.list_stocks_floats = MagicMock(
+        return_value=iter([_financial_float()])
     )
-    sut.http_session = _mock_http_session(resp)
     sut.free_float_api_duration = MagicMock()
 
     # Act
@@ -1131,19 +1022,16 @@ async def test_mdc_get_ff_with_miss_expect_duration_recorded(
 
 @pytest.mark.asyncio
 async def test_mdc_get_ff_with_miss_lock_already_released(
-    sut, mock_redis,
+    sut, mock_redis, mock_rest,
 ):
     # Arrange — lock no longer held when finally runs
     lock = _mock_lock()
     lock.locked = AsyncMock(return_value=False)
     mock_redis.lock = MagicMock(return_value=lock)
     mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock()
-    resp.json = AsyncMock(
-        return_value=_free_float_response()
+    mock_rest.list_stocks_floats = MagicMock(
+        return_value=iter([_financial_float()])
     )
-    sut.http_session = _mock_http_session(resp)
 
     # Act
     await sut.get_free_float("TEST")
@@ -1154,7 +1042,7 @@ async def test_mdc_get_ff_with_miss_lock_already_released(
 
 @pytest.mark.asyncio
 async def test_mdc_get_ff_lock_not_owned_expect_warning(
-    sut, mock_redis,
+    sut, mock_redis, mock_rest,
 ):
     # Arrange — lock.locked() returns True but release raises
     # LockNotOwnedError (lock expired between check and release)
@@ -1167,12 +1055,9 @@ async def test_mdc_get_ff_lock_not_owned_expect_warning(
     )
     mock_redis.lock = MagicMock(return_value=lock)
     mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock()
-    resp.json = AsyncMock(
-        return_value=_free_float_response()
+    mock_rest.list_stocks_floats = MagicMock(
+        return_value=iter([_financial_float()])
     )
-    sut.http_session = _mock_http_session(resp)
 
     # Act — should not raise
     result = await sut.get_free_float("TEST")
@@ -1206,7 +1091,7 @@ async def test_mdc_get_ff_pending_event_with_cache_hit(
 
 @pytest.mark.asyncio
 async def test_mdc_get_ff_pending_event_with_miss_fallthrough(
-    sut, mock_redis,
+    sut, mock_redis, mock_rest,
 ):
     # Arrange — event is set but the leader failed; cache is still
     # empty so the waiter must become the new leader.
@@ -1216,12 +1101,9 @@ async def test_mdc_get_ff_pending_event_with_miss_fallthrough(
     lock = _mock_lock()
     mock_redis.lock = MagicMock(return_value=lock)
     mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock()
-    resp.json = AsyncMock(
-        return_value=_free_float_response()
+    mock_rest.list_stocks_floats = MagicMock(
+        return_value=iter([_financial_float()])
     )
-    sut.http_session = _mock_http_session(resp)
 
     # Act
     result = await sut.get_free_float("TEST")
@@ -1233,18 +1115,16 @@ async def test_mdc_get_ff_pending_event_with_miss_fallthrough(
 
 @pytest.mark.asyncio
 async def test_mdc_get_ff_event_set_on_leader_exception(
-    sut, mock_redis,
+    sut, mock_redis, mock_rest,
 ):
     # Arrange — the API call throws; the event must still be
     # signaled so waiters never hang.
     lock = _mock_lock()
     mock_redis.lock = MagicMock(return_value=lock)
     mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock(
+    mock_rest.list_stocks_floats = MagicMock(
         side_effect=RuntimeError("API down")
     )
-    sut.http_session = _mock_http_session(resp)
 
     # Act
     with pytest.raises(RuntimeError, match="API down"):
@@ -1256,18 +1136,15 @@ async def test_mdc_get_ff_event_set_on_leader_exception(
 
 @pytest.mark.asyncio
 async def test_mdc_get_ff_pending_cleaned_after_success(
-    sut, mock_redis,
+    sut, mock_redis, mock_rest,
 ):
     # Arrange
     lock = _mock_lock()
     mock_redis.lock = MagicMock(return_value=lock)
     mock_redis.get.return_value = None
-    resp = AsyncMock()
-    resp.raise_for_status = MagicMock()
-    resp.json = AsyncMock(
-        return_value=_free_float_response()
+    mock_rest.list_stocks_floats = MagicMock(
+        return_value=iter([_financial_float()])
     )
-    sut.http_session = _mock_http_session(resp)
 
     # Act
     await sut.get_free_float("TEST")
@@ -1280,107 +1157,3 @@ async def test_mdc_get_ff_pending_cleaned_after_success(
 async def test_mdc_init_pending_free_floats_empty(sut):
     # Assert — dict initialised as empty
     assert sut._pending_free_floats == {}
-
-
-# -- get_http_session ------------------------------------------------
-
-
-@pytest.mark.asyncio
-@patch(
-    "kuhl_haus.mdp.components.market_data_cache"
-    ".aiohttp.ClientSession"
-)
-async def test_mdc_get_session_with_none_expect_created(
-    mock_cls, sut,
-):
-    # Arrange
-    mock_session = AsyncMock()
-    mock_session.closed = False
-    mock_cls.return_value = mock_session
-
-    # Act
-    result = await sut.get_http_session()
-
-    # Assert
-    mock_cls.assert_called_once()
-    assert result is mock_session
-
-
-@pytest.mark.asyncio
-async def test_mdc_get_session_with_open_expect_reused(sut):
-    # Arrange
-    existing = AsyncMock()
-    existing.closed = False
-    sut.http_session = existing
-
-    # Act
-    result = await sut.get_http_session()
-
-    # Assert
-    assert result is existing
-
-
-@pytest.mark.asyncio
-@patch(
-    "kuhl_haus.mdp.components.market_data_cache"
-    ".aiohttp.ClientSession"
-)
-async def test_mdc_get_session_with_closed_expect_new(
-    mock_cls, sut,
-):
-    # Arrange
-    closed = AsyncMock()
-    closed.closed = True
-    sut.http_session = closed
-    new_session = AsyncMock()
-    new_session.closed = False
-    mock_cls.return_value = new_session
-
-    # Act
-    result = await sut.get_http_session()
-
-    # Assert
-    mock_cls.assert_called_once()
-    assert result is new_session
-
-
-# -- close -----------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_mdc_close_with_open_session_expect_closed(sut):
-    # Arrange
-    session = AsyncMock()
-    session.closed = False
-    sut.http_session = session
-
-    # Act
-    await sut.close()
-
-    # Assert
-    session.close.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_mdc_close_with_no_session_expect_noop(sut):
-    # Arrange
-    sut.http_session = None
-
-    # Act
-    await sut.close()
-
-    # Assert — no exception raised
-
-
-@pytest.mark.asyncio
-async def test_mdc_close_with_already_closed_expect_noop(sut):
-    # Arrange
-    session = AsyncMock()
-    session.closed = True
-    sut.http_session = session
-
-    # Act
-    await sut.close()
-
-    # Assert
-    session.close.assert_not_awaited()


### PR DESCRIPTION
Replaces the experimental `aiohttp` implementation of `_fetch_free_float_with_lock` with `rest_client.list_stocks_floats(ticker=ticker)` — the same `GET /stocks/vX/float` endpoint now exposed via Massive's official Python `RESTClient`.

## Changes

- Remove `aiohttp` import, `get_http_session()`, `close()`, and `http_session` state
- Remove `massive_api_key` constructor parameter (was only needed for the aiohttp URL)
- Remove `aiohttp` from `pyproject.toml` dependencies
- Add `FinancialFloat` import from `massive.rest.models.financials`
- Update all `MarketDataCache` call sites to drop `massive_api_key` kwarg (4 files)
- Exception handling aligned with the rest of MDC: errors propagate to caller

## Commits

1. **test**: update free float tests to mock `RESTClient` (red)
2. **refactor**: implementation (green)