### PR TITLE
feat(FinlightDataAnalyzer): increase news cache limits (feed 10k, ticker 100)

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
@@ -21,6 +21,7 @@ from kuhl_haus.mdp.analyzers.analyzer import Analyzer, AnalyzerOptions
 from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
 from kuhl_haus.mdp.enum.market_data_cache_ttl import MarketDataCacheTTL
 from kuhl_haus.mdp.enum.market_data_pubsub_keys import MarketDataPubSubKeys
+from kuhl_haus.mdp.enum.finlight_data_cache import FinlightDataCache
 
 
 class FinlightDataAnalyzer(Analyzer):
@@ -69,7 +70,7 @@ class FinlightDataAnalyzer(Analyzer):
             cache_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
             cache_ttl=MarketDataCacheTTL.NEWS_FEED_LATEST.value,
             publish_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
-            cache_list_max=10000,
+            cache_list_max=FinlightDataCache.NEWS_FEED_LIST_MAX.value,
         )]
 
         # All articles go to the feed regardless of mode
@@ -89,7 +90,7 @@ class FinlightDataAnalyzer(Analyzer):
                 cache_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
                 cache_ttl=MarketDataCacheTTL.NEWS_TICKER.value,
                 publish_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
-                cache_list_max=100,
+                cache_list_max=FinlightDataCache.NEWS_TICKER_LIST_MAX.value,
             ))
 
         return results

--- a/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
@@ -69,7 +69,7 @@ class FinlightDataAnalyzer(Analyzer):
             cache_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
             cache_ttl=MarketDataCacheTTL.NEWS_FEED_LATEST.value,
             publish_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
-            cache_list_max=1000,
+            cache_list_max=10000,
         )]
 
         # All articles go to the feed regardless of mode
@@ -89,7 +89,7 @@ class FinlightDataAnalyzer(Analyzer):
                 cache_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
                 cache_ttl=MarketDataCacheTTL.NEWS_TICKER.value,
                 publish_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
-                cache_list_max=20,
+                cache_list_max=100,
             ))
 
         return results

--- a/src/kuhl_haus/mdp/enum/finlight_data_cache.py
+++ b/src/kuhl_haus/mdp/enum/finlight_data_cache.py
@@ -1,0 +1,12 @@
+"""Redis list size limits for Finlight news cache keys.
+
+Defines the maximum number of articles retained per cache key type.
+Larger feed cache supports deep history for initial client loads;
+per-ticker cache is intentionally smaller to bound per-key memory use.
+"""
+from enum import Enum
+
+
+class FinlightDataCache(Enum):
+    NEWS_FEED_LIST_MAX = 10000
+    NEWS_TICKER_LIST_MAX = 100

--- a/tests/analyzers/test_finlight_data_analyzer.py
+++ b/tests/analyzers/test_finlight_data_analyzer.py
@@ -482,7 +482,7 @@ def test_fda_extract_raw_tickers_with_deduplicated_expect_no_duplicates(sut):
 
 
 @pytest.mark.asyncio
-async def test_fda_analyze_data_with_feed_result_expect_cache_list_max_1000(sut):
+async def test_fda_analyze_data_with_feed_result_expect_cache_list_max_10000(sut):
     # Arrange
     article = _raw_article()
 
@@ -491,7 +491,7 @@ async def test_fda_analyze_data_with_feed_result_expect_cache_list_max_1000(sut)
 
     # Assert
     feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
-    assert feed.cache_list_max == 1000
+    assert feed.cache_list_max == 10000
 
 
 @pytest.mark.asyncio
@@ -511,7 +511,7 @@ async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_key_set(sut):
 
 
 @pytest.mark.asyncio
-async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_list_max_20(sut):
+async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_list_max_100(sut):
     # Arrange
     article = _enhanced_article(companies=[_company("AAPL", "XNAS")])
 
@@ -523,7 +523,7 @@ async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_list_max_20(su
         r for r in results
         if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
-    assert ticker_result.cache_list_max == 20
+    assert ticker_result.cache_list_max == 100
 
 
 @pytest.mark.asyncio
@@ -543,7 +543,7 @@ async def test_fda_analyze_data_with_raw_ticker_expect_cache_key_set(sut):
 
 
 @pytest.mark.asyncio
-async def test_fda_analyze_data_with_raw_ticker_expect_cache_list_max_20(sut):
+async def test_fda_analyze_data_with_raw_ticker_expect_cache_list_max_100(sut):
     # Arrange
     article = _raw_article(title="AAPL rises (Nasdaq: AAPL)")
 
@@ -555,4 +555,4 @@ async def test_fda_analyze_data_with_raw_ticker_expect_cache_list_max_20(sut):
         r for r in results
         if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
-    assert ticker_result.cache_list_max == 20
+    assert ticker_result.cache_list_max == 100

--- a/tests/analyzers/test_finlight_data_analyzer.py
+++ b/tests/analyzers/test_finlight_data_analyzer.py
@@ -483,7 +483,7 @@ def test_fda_extract_raw_tickers_with_deduplicated_expect_no_duplicates(sut):
 
 
 @pytest.mark.asyncio
-async def test_fda_analyze_data_with_feed_result_expect_cache_list_max_10000(sut):
+async def test_fda_analyze_data_with_feed_result_expect_cache_list_max(sut):
     # Arrange
     article = _raw_article()
 
@@ -512,7 +512,7 @@ async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_key_set(sut):
 
 
 @pytest.mark.asyncio
-async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_list_max_100(sut):
+async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_list_max(sut):
     # Arrange
     article = _enhanced_article(companies=[_company("AAPL", "XNAS")])
 
@@ -544,7 +544,7 @@ async def test_fda_analyze_data_with_raw_ticker_expect_cache_key_set(sut):
 
 
 @pytest.mark.asyncio
-async def test_fda_analyze_data_with_raw_ticker_expect_cache_list_max_100(sut):
+async def test_fda_analyze_data_with_raw_ticker_expect_cache_list_max(sut):
     # Arrange
     article = _raw_article(title="AAPL rises (Nasdaq: AAPL)")
 

--- a/tests/analyzers/test_finlight_data_analyzer.py
+++ b/tests/analyzers/test_finlight_data_analyzer.py
@@ -8,6 +8,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from kuhl_haus.mdp.analyzers.finlight_data_analyzer import FinlightDataAnalyzer
+from kuhl_haus.mdp.enum.finlight_data_cache import FinlightDataCache
 from kuhl_haus.mdp.enum.market_data_pubsub_keys import MarketDataPubSubKeys
 from kuhl_haus.mdp.enum.market_data_cache_ttl import MarketDataCacheTTL
 from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
@@ -491,7 +492,7 @@ async def test_fda_analyze_data_with_feed_result_expect_cache_list_max_10000(sut
 
     # Assert
     feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
-    assert feed.cache_list_max == 10000
+    assert feed.cache_list_max == FinlightDataCache.NEWS_FEED_LIST_MAX.value
 
 
 @pytest.mark.asyncio
@@ -523,7 +524,7 @@ async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_list_max_100(s
         r for r in results
         if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
-    assert ticker_result.cache_list_max == 100
+    assert ticker_result.cache_list_max == FinlightDataCache.NEWS_TICKER_LIST_MAX.value
 
 
 @pytest.mark.asyncio
@@ -555,4 +556,4 @@ async def test_fda_analyze_data_with_raw_ticker_expect_cache_list_max_100(sut):
         r for r in results
         if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
-    assert ticker_result.cache_list_max == 100
+    assert ticker_result.cache_list_max == FinlightDataCache.NEWS_TICKER_LIST_MAX.value


### PR DESCRIPTION
Increases `cache_list_max` for `news:feed:latest` from 1,000 → 10,000 and for `news:ticker:{ticker}` from 20 → 100. Decouples backend cache depth from the frontend display limit (controlled separately in the app).