### PR TITLE
feat(WidgetDataService): add optional limit param to get_cache (closes #47 step 1)

### DIFF
--- a/src/kuhl_haus/mdp/components/widget_data_service.py
+++ b/src/kuhl_haus/mdp/components/widget_data_service.py
@@ -184,7 +184,7 @@ class WidgetDataService:
             await self.unsubscribe(sub, websocket)
 
     @tracer.start_as_current_span("wds.get_cache")
-    async def get_cache(self, cache_key: str) -> dict:
+    async def get_cache(self, cache_key: str, limit: int = 0) -> dict:
         """Retrieve cached market data for initial client snapshot.
 
         Clients typically call this before subscribing to a feed to get current state,
@@ -192,6 +192,10 @@ class WidgetDataService:
 
         Supports both Redis string keys (returns dict) and list keys (returns list of dicts).
         List keys are used for rolling news feed caches (news:feed:latest, news:ticker:*).
+
+        Args:
+            cache_key: Redis key to fetch.
+            limit: Maximum number of items to return from list keys. 0 means fetch all.
         """
         self.logger.debug(f"wds.cache.get cache_key:{cache_key}")
         key_type = await self.redis_client.type(cache_key)
@@ -200,7 +204,8 @@ class WidgetDataService:
         key_type_str = key_type.decode() if isinstance(key_type, bytes) else key_type
 
         if key_type_str == "list":
-            values = await self.redis_client.lrange(cache_key, 0, -1)
+            end = (limit - 1) if limit > 0 else -1
+            values = await self.redis_client.lrange(cache_key, 0, end)
             if values:
                 self.logger.debug(f"wds.cache.hit cache_key:{cache_key} type:list len:{len(values)}")
                 self.cache_hit_counter.add(1)

--- a/tests/components/test_widget_data_service.py
+++ b/tests/components/test_widget_data_service.py
@@ -726,9 +726,44 @@ async def test_wds_get_cache_with_list_key_expect_parsed_list(
     # Act
     result = await sut.get_cache("news:feed:latest")
 
-    # Assert
+    # Assert — default limit=0 fetches all (LRANGE 0 -1)
     mock_redis.lrange.assert_called_once_with("news:feed:latest", 0, -1)
     assert result == [{"title": "Article 1"}, {"title": "Article 2"}]
+
+
+@pytest.mark.asyncio
+async def test_wds_get_cache_with_list_key_and_limit_expect_bounded_lrange(
+    sut, mock_redis,
+):
+    # Arrange
+    mock_redis.type = AsyncMock(return_value="list")
+    mock_redis.lrange = AsyncMock(return_value=[
+        b'{"title": "Article 1"}',
+        b'{"title": "Article 2"}',
+    ])
+
+    # Act
+    result = await sut.get_cache("news:feed:latest", limit=2)
+
+    # Assert — limit=2 maps to LRANGE 0 1
+    mock_redis.lrange.assert_called_once_with("news:feed:latest", 0, 1)
+    assert result == [{"title": "Article 1"}, {"title": "Article 2"}]
+
+
+@pytest.mark.asyncio
+async def test_wds_get_cache_with_list_key_and_limit_zero_expect_all(
+    sut, mock_redis,
+):
+    # Arrange — limit=0 is the sentinel for "fetch all"
+    mock_redis.type = AsyncMock(return_value="list")
+    mock_redis.lrange = AsyncMock(return_value=[b'{"title": "Article 1"}'])
+
+    # Act
+    result = await sut.get_cache("news:feed:latest", limit=0)
+
+    # Assert
+    mock_redis.lrange.assert_called_once_with("news:feed:latest", 0, -1)
+    assert result == [{"title": "Article 1"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds `limit: int = 0` to `WidgetDataService.get_cache()`. `limit=0` (default) fetches all items — backwards compatible. `limit=N` maps to `LRANGE 0 N-1`, bounding the Redis → WDS transfer to N items.

Part 1 of 3 for #47. Parts 2 and 3 are in kuhl-haus-mdp-servers and kuhl-haus-mdp-app respectively.