### PR TITLE
feat: per-symbol quote pub/sub feed for Quote widget

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/leaderboard_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/leaderboard_analyzer.py
@@ -86,6 +86,19 @@ class LeaderboardAnalyzer(Analyzer):
             should_publish = await self._check_publish_throttle()
             if should_publish:
                 results = await self._build_leaderboard_results()
+
+                # Forward enriched per-symbol data as a quote feed for Quote widget
+                symbol = data.get("symbol")
+                if symbol:
+                    symbol_data = await self.redis_client.hgetall(f"symbol:{symbol}:data")
+                    if symbol_data:
+                        results.append(MarketDataAnalyzerResult(
+                            data={k: self._convert_value(v) for k, v in symbol_data.items()},
+                            cache_key=f"{MarketDataPubSubKeys.QUOTE.value}:{symbol}",
+                            cache_ttl=MarketDataCacheTTL.QUOTE.value,
+                            publish_key=f"{MarketDataPubSubKeys.QUOTE.value}:{symbol}",
+                        ))
+
                 self.published_counter.add(len(results))
                 return results
 

--- a/src/kuhl_haus/mdp/enum/market_data_cache_ttl.py
+++ b/src/kuhl_haus/mdp/enum/market_data_cache_ttl.py
@@ -56,6 +56,9 @@ class MarketDataCacheTTL(Enum):
     TOP_TRADES_WIDGET_CACHE_TTL = ONE_MINUTE
     TOP_TRADES_ALL_SYMBOLS_CACHE_TTL = ONE_MINUTE
 
+    # Quote feed cache
+    QUOTE = THREE_DAYS  # Stale data > no data; timestamp in payload shows freshness
+
     # Scanner caches
     TOP_STOCKS_SCANNER = EIGHT_HOURS
     TOP_VOLUME_SCANNER = THREE_DAYS

--- a/src/kuhl_haus/mdp/enum/market_data_pubsub_keys.py
+++ b/src/kuhl_haus/mdp/enum/market_data_pubsub_keys.py
@@ -22,6 +22,9 @@ class MarketDataPubSubKeys(Enum):
     TOP_TRADES_SCANNER_FIVE_MINUTES = f'scanners:{MarketDataScannerNames.TOP_TRADES.value}:5m'
     TOP_TRADES_SCANNER_ONE_MINUTE = f'scanners:{MarketDataScannerNames.TOP_TRADES.value}:1m'
 
+    # Per-symbol quote feed
+    QUOTE = 'quote'  # Usage: f'{QUOTE.value}:{symbol}'
+
     # Single-feed scanners
     TOP_GAINERS_SCANNER = f'scanners:{MarketDataScannerNames.TOP_GAINERS.value}'
     TOP_GAPPERS_SCANNER = f'scanners:{MarketDataScannerNames.TOP_GAPPERS.value}'

--- a/tests/analyzers/test_leaderboard_analyzer.py
+++ b/tests/analyzers/test_leaderboard_analyzer.py
@@ -564,7 +564,9 @@ async def test_lba_check_market_open_reset_with_930_expect_reset(
 async def test_lba_analyze_data_with_publish_expect_results(sut):
     # Arrange
     data = {"symbol": "AAPL", "close": 150.0}
-    expected = [MagicMock(spec=MarketDataAnalyzerResult)]
+    leaderboard_results = [MagicMock(spec=MarketDataAnalyzerResult)]
+    symbol_data = {"symbol": "AAPL", "close": "150.0", "pct_change": "1.5"}
+    sut.redis_client.hgetall = AsyncMock(return_value=symbol_data)
     with patch.object(
         sut, "_check_day_boundary", new_callable=AsyncMock
     ), patch.object(
@@ -576,13 +578,19 @@ async def test_lba_analyze_data_with_publish_expect_results(sut):
         return_value=True
     ), patch.object(
         sut, "_build_leaderboard_results", new_callable=AsyncMock,
-        return_value=expected
+        return_value=leaderboard_results
     ):
         # Act
         result = await sut.analyze_data(data)
 
-    # Assert
-    assert result is expected
+    # Assert — leaderboard results included + quote result appended
+    assert result is not None
+    assert len(result) >= 2
+    quote_result = result[-1]
+    assert quote_result.publish_key == "quote:AAPL"
+    assert quote_result.cache_key == "quote:AAPL"
+    assert quote_result.data["symbol"] == "AAPL"
+    assert quote_result.data["close"] == 150.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds a real-time per-symbol enriched quote feed to the LeaderboardAnalyzer pub/sub output.

## What changed

### `MarketDataPubSubKeys`
- `QUOTE = 'quote'` — channel prefix; used as `f'quote:{symbol}'`

### `MarketDataCacheTTL`
- `QUOTE = THREE_DAYS` — stale data is better than no data; timestamp in payload lets the client show freshness

### `LeaderboardAnalyzer.analyze_data()`
Inside the existing `should_publish` branch, after building leaderboard results:
1. Reads the already-computed `symbol:{symbol}:data` hash from Redis (written by `_update_leaderboards()`)
2. Appends a `MarketDataAnalyzerResult` for `quote:{symbol}`

No new API calls. No new data computation. Throttled to ~1/sec (same as leaderboard publish). The WDS is already generic — `quote:{symbol}` subscriptions will work immediately without WDS changes.

## What's next
- Quote widget (`Quote.vue`) in `kuhl-haus-mdp-app` — separate PR

refs #49