### PR TITLE
fix(wds): snapshot set before iteration; fix exc_info in logger call

### DIFF
--- a/src/kuhl_haus/mdp/components/widget_data_service.py
+++ b/src/kuhl_haus/mdp/components/widget_data_service.py
@@ -276,7 +276,7 @@ class WidgetDataService:
                         disconnected = []
                         sent_count = 0
 
-                        for ws in self.subscriptions[feed]:
+                        for ws in list(self.subscriptions[feed]):  # snapshot prevents RuntimeError on concurrent disconnect
                             try:
                                 await ws.send_text(data)
                                 sent_count += 1
@@ -298,5 +298,5 @@ class WidgetDataService:
             raise
 
         except Exception as e:
-            self.logger.error(f"wds.pubsub.error error:{repr(e)}", e)
+            self.logger.error(f"wds.pubsub.error error:{repr(e)}", exc_info=True)
             raise


### PR DESCRIPTION
Fixes two bugs in `_handle_pubsub()` that trigger on concurrent WebSocket disconnect.

## Bug 1 — `RuntimeError: Set changed size during iteration`

`self.subscriptions[feed]` is a Python `set`. When a `WebSocketDisconnect` occurs during fan-out, another coroutine (e.g. the `finally` block in `websocket_endpoint`) can call `unsubscribe()` and modify the set while `_handle_pubsub` is still iterating it.

**Fix:** `for ws in list(self.subscriptions[feed]):` — iterate a snapshot copy.

## Bug 2 — `TypeError: not all arguments converted during string formatting`

`self.logger.error(f"...", e)` passes the exception as a positional `%`-format argument. Since the message is already an f-string with no `%s` tokens, the logging module raises `TypeError` while trying to format the log record — which then *swallows* the original exception details.

**Fix:** `exc_info=True` — attaches the full traceback correctly.

Reported in kuhl-haus-mdp-servers#35.