### PR TITLE
fix(lba): publish quote:{symbol} on every agg, not just on leaderboard publish

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/leaderboard_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/leaderboard_analyzer.py
@@ -82,25 +82,34 @@ class LeaderboardAnalyzer(Analyzer):
             # Update leaderboards atomically
             await self._update_leaderboards(data)
 
-            # Throttled publish (only one instance publishes per second)
+            # Always publish per-symbol quote — every instance, every agg event.
+            # The leaderboard snapshots (top 500 fan-out) are throttled; the quote
+            # feed is per-symbol so there is no fan-out concern.
+            symbol = data.get("symbol")
+            quote_result = None
+            if symbol:
+                symbol_data = await self.redis_client.hgetall(f"symbol:{symbol}:data")
+                if symbol_data:
+                    quote_result = MarketDataAnalyzerResult(
+                        data={k: self._convert_value(v) for k, v in symbol_data.items()},
+                        cache_key=f"{MarketDataPubSubKeys.QUOTE.value}:{symbol}",
+                        cache_ttl=MarketDataCacheTTL.QUOTE.value,
+                        publish_key=f"{MarketDataPubSubKeys.QUOTE.value}:{symbol}",
+                    )
+
+            # Throttled leaderboard publish (only one instance publishes per second)
             should_publish = await self._check_publish_throttle()
             if should_publish:
                 results = await self._build_leaderboard_results()
-
-                # Forward enriched per-symbol data as a quote feed for Quote widget
-                symbol = data.get("symbol")
-                if symbol:
-                    symbol_data = await self.redis_client.hgetall(f"symbol:{symbol}:data")
-                    if symbol_data:
-                        results.append(MarketDataAnalyzerResult(
-                            data={k: self._convert_value(v) for k, v in symbol_data.items()},
-                            cache_key=f"{MarketDataPubSubKeys.QUOTE.value}:{symbol}",
-                            cache_ttl=MarketDataCacheTTL.QUOTE.value,
-                            publish_key=f"{MarketDataPubSubKeys.QUOTE.value}:{symbol}",
-                        ))
-
+                if quote_result:
+                    results.append(quote_result)
                 self.published_counter.add(len(results))
                 return results
+
+            # Return just the quote result when not publishing leaderboards
+            if quote_result:
+                self.published_counter.add(1)
+                return [quote_result]
 
             return None
 

--- a/tests/analyzers/test_leaderboard_analyzer.py
+++ b/tests/analyzers/test_leaderboard_analyzer.py
@@ -594,9 +594,11 @@ async def test_lba_analyze_data_with_publish_expect_results(sut):
 
 
 @pytest.mark.asyncio
-async def test_lba_analyze_data_with_no_publish_expect_none(sut):
-    # Arrange
+async def test_lba_analyze_data_with_no_publish_expect_quote_only(sut):
+    # Arrange: no leaderboard publish, but quote result should still be returned
     data = {"symbol": "AAPL", "close": 150.0}
+    symbol_data = {"symbol": "AAPL", "close": "150.0", "pct_change": "1.5"}
+    sut.redis_client.hgetall = AsyncMock(return_value=symbol_data)
     with patch.object(
         sut, "_check_day_boundary", new_callable=AsyncMock
     ), patch.object(
@@ -610,8 +612,11 @@ async def test_lba_analyze_data_with_no_publish_expect_none(sut):
         # Act
         result = await sut.analyze_data(data)
 
-    # Assert
-    assert result is None
+    # Assert — quote result returned even without leaderboard publish
+    assert result is not None
+    assert len(result) == 1
+    assert result[0].publish_key == "quote:AAPL"
+    assert result[0].data["symbol"] == "AAPL"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The `quote:{symbol}` pub/sub result was inside the `if should_publish:` branch. `should_publish` is a distributed throttle — only one of N LBA instances wins the election per second. That one instance only published a quote for the single ticker that triggered *its* election. All other instances and tickers got no pub/sub update. The Quote widget received its initial data from the 3-day cache but never updated live.

## Fix

Build the quote result unconditionally for every agg event, on every instance:

- When `should_publish`: return leaderboard results + quote result (unchanged from user's perspective)
- When not `should_publish`: return just the quote result

The leaderboard fan-out (broadcasting top-500 lists to all subscribers) stays throttled — that's the expensive part. The quote channel is `quote:{symbol}` — one key, no fan-out — so per-instance, per-event publish is fine.

## Effect

`quote:{symbol}` now receives ~1 update/sec on every active ticker from every LBA instance processing that ticker's agg messages. Widget updates are live.