### PR TITLE
feat(LeaderboardAnalyzer): add prev_day open/high/low to symbol metadata

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/leaderboard_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/leaderboard_analyzer.py
@@ -141,6 +141,9 @@ class LeaderboardAnalyzer(Analyzer):
 
         # Calculate metrics
         prev_day_close = snapshot.prev_day.close if snapshot and snapshot.prev_day else close
+        prev_day_open = snapshot.prev_day.open if snapshot and snapshot.prev_day else 0
+        prev_day_high = snapshot.prev_day.high if snapshot and snapshot.prev_day else 0
+        prev_day_low = snapshot.prev_day.low if snapshot and snapshot.prev_day else 0
         prev_day_volume = snapshot.prev_day.volume if snapshot and snapshot.prev_day else volume
         prev_day_vwap = snapshot.prev_day.vwap if snapshot and snapshot.prev_day else vwap
 
@@ -184,6 +187,9 @@ class LeaderboardAnalyzer(Analyzer):
             "average_size": event.get("average_size") or 0,
             "avg_volume": avg_volume or 0,
             "prev_day_close": prev_day_close,
+            "prev_day_open": prev_day_open,
+            "prev_day_high": prev_day_high,
+            "prev_day_low": prev_day_low,
             "prev_day_volume": prev_day_volume,
             "prev_day_vwap": prev_day_vwap,
             "change": change,

--- a/tests/analyzers/test_leaderboard_analyzer.py
+++ b/tests/analyzers/test_leaderboard_analyzer.py
@@ -39,6 +39,9 @@ def mock_cache():
     cache = AsyncMock()
     snapshot = MagicMock()
     snapshot.prev_day.close = 100.0
+    snapshot.prev_day.open = 98.0
+    snapshot.prev_day.high = 105.0
+    snapshot.prev_day.low = 97.0
     snapshot.prev_day.volume = 50000
     snapshot.prev_day.vwap = 101.0
     cache.get_ticker_snapshot.return_value = snapshot
@@ -280,6 +283,9 @@ async def test_lba_update_leaderboards_with_no_snapshot_expect_fallback(
     pipe.hset.assert_called_once()
     mapping = pipe.hset.call_args[1]["mapping"]
     assert mapping["prev_day_close"] == 50.0
+    assert mapping["prev_day_open"] == 0     # no snapshot — fallback
+    assert mapping["prev_day_high"] == 0     # no snapshot — fallback
+    assert mapping["prev_day_low"] == 0      # no snapshot — fallback
     assert mapping["prev_day_volume"] == 200
 
 


### PR DESCRIPTION
Adds `prev_day_open`, `prev_day_high`, and `prev_day_low` to the symbol metadata hash maintained by `LeaderboardAnalyzer`.

These fields are sourced from `snapshot.prev_day.open/high/low` (already available from the cached `TickerSnapshot`) and fall back to `0` when no snapshot is available — consistent with the existing `prev_day_close` fallback pattern.

Required by the Quote widget to display a complete Previous Day section (refs kuhl-haus/kuhl-haus-mdp-app#97).

Closes refs #54