### PR TITLE
feat(AnalyzerOptions): add finlight_api_key and kwargs fields

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/analyzer.py
@@ -1,11 +1,12 @@
 """Base analyzer and configuration for market data processing.
 
 Provides abstract interface and shared client factories for Redis-backed
-analyzers that consume WebSocket events from Massive.com.
+analyzers that consume WebSocket events from Massive.com and Finlight.
 """
-from dataclasses import dataclass
-from typing import Optional, List
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, List
 from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
+from finlight_client import ApiConfig, FinlightApi
 from massive.rest import RESTClient
 import redis.asyncio as aioredis
 
@@ -14,17 +15,37 @@ import redis.asyncio as aioredis
 class AnalyzerOptions:
     """Configuration for analyzer instances.
 
-    Encapsulates API keys and connection URLs for Massive.com REST API
-    and Redis. Factory methods ensure consistent client instantiation
-    across all analyzer implementations.
+    Encapsulates API keys and connection URLs for the two market data
+    sources (Massive.com and Finlight) and Redis. Factory methods ensure
+    consistent client instantiation across all analyzer implementations.
+
+    Attributes:
+        redis_url: Redis connection URL. Required for all stateful analyzers.
+        massive_api_key: Massive.com REST API key. Required for analyzers
+            that fetch reference data (snapshots, floats, avg volume).
+        finlight_api_key: Finlight REST/WebSocket API key. Required for
+            analyzers that process or query financial news data.
+        kwargs: Arbitrary keyword arguments for subclass-specific
+            configuration. Allows analyzer subclasses to accept additional
+            parameters without modifying this class or breaking existing
+            implementations.
     """
     redis_url: Optional[str] = None
     massive_api_key: Optional[str] = None
+    finlight_api_key: Optional[str] = None
+    kwargs: Dict[str, Any] = field(default_factory=dict)
 
     def new_rest_client(self):
-        """Create Massive.com REST client if API key configured."""
+        """Create Massive.com REST client if API key is configured."""
         if self.massive_api_key:
             return RESTClient(api_key=self.massive_api_key)
+        else:
+            return None
+
+    def new_finlight_client(self):
+        """Create Finlight API client if API key is configured."""
+        if self.finlight_api_key:
+            return FinlightApi(config=ApiConfig(api_key=self.finlight_api_key))
         else:
             return None
 

--- a/tests/analyzers/test_analyzer.py
+++ b/tests/analyzers/test_analyzer.py
@@ -35,19 +35,30 @@ def test_ao_init_with_defaults_expect_none_fields():
     # Assert
     assert sut.redis_url is None
     assert sut.massive_api_key is None
+    assert sut.finlight_api_key is None
+    assert sut.kwargs == {}
 
 
 def test_ao_init_with_values_expect_fields_set():
     # Arrange
     url = "redis://host:6379"
     key = "my-key"
+    fl_key = "fl-key"
+    extra = {"timeout": 30, "retries": 3}
 
     # Act
-    sut = AnalyzerOptions(redis_url=url, massive_api_key=key)
+    sut = AnalyzerOptions(
+        redis_url=url,
+        massive_api_key=key,
+        finlight_api_key=fl_key,
+        kwargs=extra,
+    )
 
     # Assert
     assert sut.redis_url == url
     assert sut.massive_api_key == key
+    assert sut.finlight_api_key == fl_key
+    assert sut.kwargs == extra
 
 
 # ── AnalyzerOptions.new_rest_client ──────────────────────────────────
@@ -141,6 +152,71 @@ def test_ao_new_redis_client_with_custom_params_expect_overrides():
     )
     assert result is mock_from_url.return_value
 
+
+
+
+# ── AnalyzerOptions.new_finlight_client ──────────────────────────────
+
+
+def test_ao_new_finlight_client_with_api_key_expect_finlight_client():
+    # Arrange
+    sut = _make_options(finlight_api_key="fl-key")
+
+    # Act
+    with patch(
+        "kuhl_haus.mdp.analyzers.analyzer.FinlightApi"
+    ) as mock_api, patch(
+        "kuhl_haus.mdp.analyzers.analyzer.ApiConfig"
+    ) as mock_cfg:
+        result = sut.new_finlight_client()
+
+    # Assert
+    mock_cfg.assert_called_once_with(api_key="fl-key")
+    mock_api.assert_called_once_with(config=mock_cfg.return_value)
+    assert result is mock_api.return_value
+
+
+def test_ao_new_finlight_client_with_no_key_expect_none():
+    # Arrange
+    sut = _make_options()
+
+    # Act
+    result = sut.new_finlight_client()
+
+    # Assert
+    assert result is None
+
+
+# ── AnalyzerOptions.kwargs ────────────────────────────────────────────
+
+
+def test_ao_kwargs_with_default_expect_empty_dict():
+    # Arrange / Act
+    sut = AnalyzerOptions()
+
+    # Assert
+    assert sut.kwargs == {}
+
+
+def test_ao_kwargs_with_values_expect_dict_stored():
+    # Arrange / Act
+    sut = AnalyzerOptions(kwargs={"timeout": 30, "retries": 3})
+
+    # Assert
+    assert sut.kwargs["timeout"] == 30
+    assert sut.kwargs["retries"] == 3
+
+
+def test_ao_kwargs_instances_are_independent():
+    # Arrange — two instances should not share the same dict
+    a = AnalyzerOptions()
+    b = AnalyzerOptions()
+
+    # Act
+    a.kwargs["foo"] = "bar"
+
+    # Assert
+    assert "foo" not in b.kwargs
 
 # ── Analyzer.__init__ ────────────────────────────────────────────────
 


### PR DESCRIPTION
Adds two new fields to `AnalyzerOptions`:

**`finlight_api_key: Optional[str]`**
Provides Finlight REST/WebSocket API access to analyzer subclasses, symmetric with the existing `massive_api_key`. Includes a `new_finlight_client()` factory method (returns `FinlightApi` when the key is set, `None` otherwise) consistent with the `new_rest_client()` pattern.

**`kwargs: Dict[str, Any]`** (defaults to `{}`)
Escape hatch for subclass-specific configuration that does not belong in `AnalyzerOptions` itself. Allows new per-analyzer parameters without modifying the base class or breaking existing implementations. Uses `field(default_factory=dict)` to prevent shared mutable default state.

5 new tests covering: defaults, explicit values, `new_finlight_client()` with and without key, `kwargs` default, and instance independence.