### PR TITLE
feat(FinlightDataAnalyzer): make cache list limits configurable via AnalyzerOptions.kwargs

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
@@ -48,6 +48,14 @@ class FinlightDataAnalyzer(Analyzer):
             re.IGNORECASE,
         )
 
+        # Cache size limits — default to enum values, overridable via AnalyzerOptions.kwargs
+        self.news_feed_list_max: int = options.kwargs.get(
+            "news_feed_list_max", FinlightDataCache.NEWS_FEED_LIST_MAX.value
+        )
+        self.news_ticker_list_max: int = options.kwargs.get(
+            "news_ticker_list_max", FinlightDataCache.NEWS_TICKER_LIST_MAX.value
+        )
+
     async def rehydrate(self):
         """No-op — stateless analyzer; no Redis state to restore."""
         pass
@@ -70,7 +78,7 @@ class FinlightDataAnalyzer(Analyzer):
             cache_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
             cache_ttl=MarketDataCacheTTL.NEWS_FEED_LATEST.value,
             publish_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
-            cache_list_max=FinlightDataCache.NEWS_FEED_LIST_MAX.value,
+            cache_list_max=self.news_feed_list_max,
         )]
 
         # All articles go to the feed regardless of mode
@@ -90,7 +98,7 @@ class FinlightDataAnalyzer(Analyzer):
                 cache_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
                 cache_ttl=MarketDataCacheTTL.NEWS_TICKER.value,
                 publish_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
-                cache_list_max=FinlightDataCache.NEWS_TICKER_LIST_MAX.value,
+                cache_list_max=self.news_ticker_list_max,
             ))
 
         return results

--- a/tests/analyzers/test_finlight_data_analyzer.py
+++ b/tests/analyzers/test_finlight_data_analyzer.py
@@ -557,3 +557,67 @@ async def test_fda_analyze_data_with_raw_ticker_expect_cache_list_max(sut):
         if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
     assert ticker_result.cache_list_max == FinlightDataCache.NEWS_TICKER_LIST_MAX.value
+
+@pytest.mark.asyncio
+async def test_fda_init_with_no_kwargs_expect_enum_defaults():
+    # Arrange / Act
+    opts = AnalyzerOptions(redis_url="redis://localhost")
+    sut = FinlightDataAnalyzer(opts)
+
+    # Assert — defaults come from enum values
+    assert sut.news_feed_list_max == FinlightDataCache.NEWS_FEED_LIST_MAX.value
+    assert sut.news_ticker_list_max == FinlightDataCache.NEWS_TICKER_LIST_MAX.value
+
+
+@pytest.mark.asyncio
+async def test_fda_init_with_kwargs_overrides_expect_custom_limits():
+    # Arrange / Act
+    opts = AnalyzerOptions(
+        redis_url="redis://localhost",
+        kwargs={"news_feed_list_max": 500, "news_ticker_list_max": 250},
+    )
+    sut = FinlightDataAnalyzer(opts)
+
+    # Assert — kwargs override enum defaults
+    assert sut.news_feed_list_max == 500
+    assert sut.news_ticker_list_max == 250
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_kwargs_override_expect_custom_feed_limit():
+    # Arrange
+    opts = AnalyzerOptions(
+        redis_url="redis://localhost",
+        kwargs={"news_feed_list_max": 999},
+    )
+    sut = FinlightDataAnalyzer(opts)
+    article = _raw_article()
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert — feed result uses overridden limit
+    feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
+    assert feed.cache_list_max == 999
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_kwargs_override_expect_custom_ticker_limit():
+    # Arrange
+    opts = AnalyzerOptions(
+        redis_url="redis://localhost",
+        kwargs={"news_ticker_list_max": 42},
+    )
+    sut = FinlightDataAnalyzer(opts)
+    article = _enhanced_article(companies=[_company("AAPL", "XNAS")])
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert — ticker result uses overridden limit
+    ticker_result = next(
+        r for r in results
+        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+    )
+    assert ticker_result.cache_list_max == 42
+


### PR DESCRIPTION
`NEWS_FEED_LIST_MAX` and `NEWS_TICKER_LIST_MAX` enum values remain the defaults but can now be overridden at runtime via `AnalyzerOptions.kwargs`:

```python
AnalyzerOptions(
    redis_url=...,
    kwargs={
        "news_feed_list_max": 500,
        "news_ticker_list_max": 250,
    }
)
```

This allows `fdp_server.py` to surface these limits as environment variables and pass them through at startup — no code changes required to adjust cache sizes per deployment.

4 new tests covering defaults, overrides, and end-to-end result routing.