### PR TITLE
fix(FinlightDataProcessor): delete wrong-type string keys before lpush

### DIFF
--- a/src/kuhl_haus/mdp/components/finlight_data_processor.py
+++ b/src/kuhl_haus/mdp/components/finlight_data_processor.py
@@ -262,7 +262,18 @@ class FinlightDataProcessor:
         pipe = self.redis_client.pipeline(transaction=False)
         if analyzer_result.cache_key:
             if analyzer_result.cache_list_max is not None:
-                # Rolling list: prepend + trim to max + optional TTL
+                # Rolling list: prepend + trim to max + optional TTL.
+                # Guard against WRONGTYPE: if the key was previously stored as a string
+                # (written before list-mode caching was introduced), delete it first so
+                # lpush doesn't raise. Type check is async before the pipeline.
+                key_type = await self.redis_client.type(analyzer_result.cache_key)
+                key_type_str = key_type.decode() if isinstance(key_type, bytes) else key_type
+                if key_type_str not in ("list", "none"):
+                    await self.redis_client.delete(analyzer_result.cache_key)
+                    self.logger.warning(
+                        f"Deleted wrong-type key {analyzer_result.cache_key!r} "
+                        f"(was {key_type_str!r}, expected list)"
+                    )
                 pipe.lpush(analyzer_result.cache_key, result_json)
                 pipe.ltrim(analyzer_result.cache_key, 0, analyzer_result.cache_list_max - 1)
                 if analyzer_result.cache_ttl and analyzer_result.cache_ttl > 0:

--- a/tests/components/test_finlight_data_processor.py
+++ b/tests/components/test_finlight_data_processor.py
@@ -836,6 +836,7 @@ async def test_fdp_cache_result_with_list_max_and_ttl_expect_lpush_ltrim_expire(
     pipe.execute = AsyncMock()
     mock_redis = MagicMock()
     mock_redis.pipeline.return_value = pipe
+    mock_redis.type = AsyncMock(return_value="none")  # new key, no type mismatch
     sut.redis_client = mock_redis
     result = MarketDataAnalyzerResult(
         data={"title": "Breaking news"},
@@ -866,6 +867,7 @@ async def test_fdp_cache_result_with_list_max_and_zero_ttl_expect_no_expire(sut)
     pipe.execute = AsyncMock()
     mock_redis = MagicMock()
     mock_redis.pipeline.return_value = pipe
+    mock_redis.type = AsyncMock(return_value="none")
     sut.redis_client = mock_redis
     result = MarketDataAnalyzerResult(
         data={"title": "Ticker news"},
@@ -885,3 +887,58 @@ async def test_fdp_cache_result_with_list_max_and_zero_ttl_expect_no_expire(sut)
     pipe.expire.assert_not_called()
     pipe.set.assert_not_called()
     pipe.setex.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_fdp_cache_result_with_string_key_expect_delete_then_lpush(sut):
+    # Arrange — key exists as a string (written before list-mode caching was introduced)
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    mock_redis = MagicMock()
+    mock_redis.pipeline.return_value = pipe
+    mock_redis.type = AsyncMock(return_value="string")  # wrong type
+    mock_redis.delete = AsyncMock()
+    sut.redis_client = mock_redis
+    result = MarketDataAnalyzerResult(
+        data={"ticker": "META"},
+        cache_key="news:ticker:META",
+        cache_ttl=3600,
+        publish_key="news:ticker:META",
+        cache_list_max=100,
+    )
+
+    # Act
+    await sut._cache_result(result)
+
+    # Assert — wrong-type key deleted before lpush
+    mock_redis.delete.assert_awaited_once_with("news:ticker:META")
+    expected_json = json.dumps({"ticker": "META"})
+    pipe.lpush.assert_called_once_with("news:ticker:META", expected_json)
+    pipe.ltrim.assert_called_once_with("news:ticker:META", 0, 99)
+    pipe.expire.assert_called_once_with("news:ticker:META", 3600)
+
+
+@pytest.mark.asyncio
+async def test_fdp_cache_result_with_list_key_expect_no_delete(sut):
+    # Arrange — key already exists as a list (correct type, no DEL needed)
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    mock_redis = MagicMock()
+    mock_redis.pipeline.return_value = pipe
+    mock_redis.type = AsyncMock(return_value="list")
+    mock_redis.delete = AsyncMock()
+    sut.redis_client = mock_redis
+    result = MarketDataAnalyzerResult(
+        data={"ticker": "META"},
+        cache_key="news:ticker:META",
+        cache_ttl=3600,
+        publish_key="news:ticker:META",
+        cache_list_max=100,
+    )
+
+    # Act
+    await sut._cache_result(result)
+
+    # Assert — no delete for correct type
+    mock_redis.delete.assert_not_awaited()
+    pipe.lpush.assert_called_once()
+


### PR DESCRIPTION
## Root Cause

Between commits `7ca77f6` and `1f0f16c`, per-ticker articles were cached with `setex` (string). After list-mode caching was introduced, subsequent `lpush` calls against those existing string keys raised Redis `WRONGTYPE` errors, silently dropping articles and incrementing the `error` counter.

This explains why META (and others) have a single string article in the per-ticker cache while the feed has 50+ entries.

## Fix

Before `lpush`, check the Redis key type. If it is anything other than `list` or `none`, delete the key and log a warning. This is a one-time migration path — once the stale string keys are gone, the type check is essentially free.

## Tests

- String key detected → delete then lpush (WRONGTYPE prevented)
- List key detected → no delete, lpush proceeds normally
- Existing tests updated to mock `redis_client.type`