### PR TITLE
feat(FinlightDataAnalyzer): configurable cache TTLs via kwargs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -125,6 +125,15 @@ through a pluggable analyzer, writing results to Redis.
      - Maximum number of articles retained per ticker Redis list cache
        (``news:ticker:<TICKER>``). Overrides the ``FinlightDataCache.NEWS_TICKER_LIST_MAX``
        enum default.
+   * - ``NEWS_FEED_CACHE_TTL``
+     - ``86400`` (1 day)
+     - Redis TTL in seconds for the news feed list cache (``news:feed:latest``).
+       Overrides the ``MarketDataCacheTTL.NEWS_FEED_LATEST`` enum default.
+   * - ``NEWS_TICKER_CACHE_TTL``
+     - ``259200`` (3 days)
+     - Redis TTL in seconds for per-ticker news list caches
+       (``news:ticker:<TICKER>``). Overrides the ``MarketDataCacheTTL.NEWS_TICKER``
+       enum default.
 
 ----
 

--- a/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
@@ -56,6 +56,14 @@ class FinlightDataAnalyzer(Analyzer):
             "news_ticker_list_max", FinlightDataCache.NEWS_TICKER_LIST_MAX.value
         )
 
+        # Cache TTLs — default to enum values, overridable via AnalyzerOptions.kwargs
+        self.news_feed_cache_ttl: int = options.kwargs.get(
+            "news_feed_cache_ttl", MarketDataCacheTTL.NEWS_FEED_LATEST.value
+        )
+        self.news_ticker_cache_ttl: int = options.kwargs.get(
+            "news_ticker_cache_ttl", MarketDataCacheTTL.NEWS_TICKER.value
+        )
+
     async def rehydrate(self):
         """No-op — stateless analyzer; no Redis state to restore."""
         pass
@@ -76,7 +84,7 @@ class FinlightDataAnalyzer(Analyzer):
         results: List[MarketDataAnalyzerResult] = [MarketDataAnalyzerResult(
             data=data,
             cache_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
-            cache_ttl=MarketDataCacheTTL.NEWS_FEED_LATEST.value,
+            cache_ttl=self.news_feed_cache_ttl,
             publish_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
             cache_list_max=self.news_feed_list_max,
         )]
@@ -96,7 +104,7 @@ class FinlightDataAnalyzer(Analyzer):
             results.append(MarketDataAnalyzerResult(
                 data=data,
                 cache_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
-                cache_ttl=MarketDataCacheTTL.NEWS_TICKER.value,
+                cache_ttl=self.news_ticker_cache_ttl,
                 publish_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
                 cache_list_max=self.news_ticker_list_max,
             ))

--- a/tests/analyzers/test_finlight_data_analyzer.py
+++ b/tests/analyzers/test_finlight_data_analyzer.py
@@ -621,3 +621,134 @@ async def test_fda_analyze_data_with_kwargs_override_expect_custom_ticker_limit(
     )
     assert ticker_result.cache_list_max == 42
 
+
+
+# ── news_feed_cache_ttl / news_ticker_cache_ttl (issue kuhl-haus-project-roadmap#1) ─
+
+
+@pytest.mark.asyncio
+async def test_fda_init_with_no_kwargs_expect_ttl_enum_defaults():
+    """news_feed_cache_ttl and news_ticker_cache_ttl default to enum values."""
+    # Arrange / Act
+    opts = AnalyzerOptions(redis_url="redis://localhost")
+    sut = FinlightDataAnalyzer(opts)
+
+    # Assert
+    assert sut.news_feed_cache_ttl == MarketDataCacheTTL.NEWS_FEED_LATEST.value
+    assert sut.news_ticker_cache_ttl == MarketDataCacheTTL.NEWS_TICKER.value
+
+
+@pytest.mark.asyncio
+async def test_fda_init_with_ttl_kwargs_expect_custom_ttls():
+    """kwargs override takes effect for both TTL attributes."""
+    # Arrange / Act
+    opts = AnalyzerOptions(
+        redis_url="redis://localhost",
+        kwargs={"news_feed_cache_ttl": 3600, "news_ticker_cache_ttl": 7200},
+    )
+    sut = FinlightDataAnalyzer(opts)
+
+    # Assert
+    assert sut.news_feed_cache_ttl == 3600
+    assert sut.news_ticker_cache_ttl == 7200
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_default_feed_ttl_expect_enum_value():
+    """Feed result cache_ttl uses MarketDataCacheTTL.NEWS_FEED_LATEST by default."""
+    # Arrange
+    opts = AnalyzerOptions(redis_url="redis://localhost")
+    sut = FinlightDataAnalyzer(opts)
+    article = _raw_article()
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert
+    feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
+    assert feed.cache_ttl == MarketDataCacheTTL.NEWS_FEED_LATEST.value
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_custom_feed_ttl_expect_override_used():
+    """Feed result cache_ttl uses the kwarg-overridden value."""
+    # Arrange
+    custom_ttl = 3600
+    opts = AnalyzerOptions(
+        redis_url="redis://localhost",
+        kwargs={"news_feed_cache_ttl": custom_ttl},
+    )
+    sut = FinlightDataAnalyzer(opts)
+    article = _raw_article()
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert
+    feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
+    assert feed.cache_ttl == custom_ttl
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_default_ticker_ttl_expect_enum_value():
+    """Ticker result cache_ttl uses MarketDataCacheTTL.NEWS_TICKER by default."""
+    # Arrange
+    opts = AnalyzerOptions(redis_url="redis://localhost")
+    sut = FinlightDataAnalyzer(opts)
+    article = _enhanced_article(companies=[_company("AAPL", "XNAS")])
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert
+    ticker = next(
+        r for r in results
+        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+    )
+    assert ticker.cache_ttl == MarketDataCacheTTL.NEWS_TICKER.value
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_custom_ticker_ttl_expect_override_used():
+    """Ticker result cache_ttl uses the kwarg-overridden value."""
+    # Arrange
+    custom_ttl = 7200
+    opts = AnalyzerOptions(
+        redis_url="redis://localhost",
+        kwargs={"news_ticker_cache_ttl": custom_ttl},
+    )
+    sut = FinlightDataAnalyzer(opts)
+    article = _enhanced_article(companies=[_company("AAPL", "XNAS")])
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert
+    ticker = next(
+        r for r in results
+        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+    )
+    assert ticker.cache_ttl == custom_ttl
+
+
+@pytest.mark.asyncio
+async def test_fda_analyze_data_with_custom_ticker_ttl_expect_raw_ticker_override_used():
+    """Raw-mode ticker result also uses the kwarg-overridden TTL."""
+    # Arrange
+    custom_ttl = 1800
+    opts = AnalyzerOptions(
+        redis_url="redis://localhost",
+        kwargs={"news_ticker_cache_ttl": custom_ttl},
+    )
+    sut = FinlightDataAnalyzer(opts)
+    article = _raw_article(title="Apple (Nasdaq: AAPL) beats estimates")
+
+    # Act
+    results = await sut.analyze_data(article)
+
+    # Assert
+    ticker = next(
+        r for r in results
+        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+    )
+    assert ticker.cache_ttl == custom_ttl


### PR DESCRIPTION
Adds `news_feed_cache_ttl` and `news_ticker_cache_ttl` to `FinlightDataAnalyzer`, following the same `AnalyzerOptions.kwargs` pattern as `news_feed_list_max` / `news_ticker_list_max`.

Companion PR to wire env vars in `kuhl-haus-mdp-servers` will follow once this merges.

refs kuhl-haus/kuhl-haus-project-roadmap#1

---
**Commit 1 (tests):** 5 failing tests proving the missing feature  
**Commit 2 (impl):** Implementation making all tests pass