### PR TITLE
docs: fix NEWS_FEED_CACHE_TTL and NEWS_TICKER_CACHE_TTL default values

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -126,11 +126,11 @@ through a pluggable analyzer, writing results to Redis.
        (``news:ticker:<TICKER>``). Overrides the ``FinlightDataCache.NEWS_TICKER_LIST_MAX``
        enum default.
    * - ``NEWS_FEED_CACHE_TTL``
-     - ``86400`` (1 day)
+     - ``172800`` (2 days)
      - Redis TTL in seconds for the news feed list cache (``news:feed:latest``).
        Overrides the ``MarketDataCacheTTL.NEWS_FEED_LATEST`` enum default.
    * - ``NEWS_TICKER_CACHE_TTL``
-     - ``259200`` (3 days)
+     - ``604800`` (7 days)
      - Redis TTL in seconds for per-ticker news list caches
        (``news:ticker:<TICKER>``). Overrides the ``MarketDataCacheTTL.NEWS_TICKER``
        enum default.


### PR DESCRIPTION
Corrects the default values in `docs/configuration.rst` for the two new FDP env vars:

- `NEWS_FEED_CACHE_TTL`: `86400` → `172800` (2 days — `MarketDataCacheTTL.NEWS_FEED_LATEST`)
- `NEWS_TICKER_CACHE_TTL`: `259200` → `604800` (7 days — `MarketDataCacheTTL.NEWS_TICKER`)

Tom increased both TTLs today; the docs in PR #64 used stale values.