### PR TITLE
feat(MassiveDataProcessor): accept AnalyzerOptions as constructor param (WDC/MDC split)

### DIFF
--- a/src/kuhl_haus/mdp/components/massive_data_processor.py
+++ b/src/kuhl_haus/mdp/components/massive_data_processor.py
@@ -54,15 +54,14 @@ class MassiveDataProcessor:
         rabbitmq_url: str,
         queue_name: str,
         redis_url: str,
-        massive_api_key: str,
         analyzer_class: Any,
+        analyzer_options: AnalyzerOptions,
         prefetch_count: int = 100,  # Higher for async throughput
         max_concurrent_tasks: int = 500,  # Concurrent processing limit
     ):
         self.rabbitmq_url = rabbitmq_url
         self.queue_name = queue_name
         self.redis_url = redis_url
-        self.massive_api_key = massive_api_key
         self.prefetch_count = prefetch_count
         self.max_concurrent_tasks = max_concurrent_tasks
 
@@ -75,7 +74,7 @@ class MassiveDataProcessor:
         # Analyzer
         self.analyzer: Analyzer = None
         self.analyzer_class = analyzer_class
-        self.analyzer_options = AnalyzerOptions(redis_url=redis_url, massive_api_key=massive_api_key)
+        self.analyzer_options = analyzer_options
 
         # Concurrency control
         self.semaphore = asyncio.Semaphore(max_concurrent_tasks)

--- a/tests/components/test_massive_data_processor.py
+++ b/tests/components/test_massive_data_processor.py
@@ -700,3 +700,99 @@ async def test_mdp_stop_with_no_conns_expect_no_errors(
     assert sut.running is False
 
 
+
+
+# ── Issue #68: accept AnalyzerOptions as constructor param ─────────────────────
+
+
+def test_mdp_init_with_analyzer_options_expect_used(
+    mock_meter, mock_setup_logging, mock_analyzer_class
+):
+    """MassiveDataProcessor must accept analyzer_options as a constructor param
+    and use it directly instead of constructing AnalyzerOptions internally."""
+    from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
+
+    # Arrange
+    opts = AnalyzerOptions(redis_url="redis://mdc:6379/0", massive_api_key="mdc-key")
+
+    # Act
+    sut = MassiveDataProcessor(
+        rabbitmq_url="amqp://localhost/",
+        queue_name="q1",
+        redis_url="redis://wdc:6379/1",
+        analyzer_class=mock_analyzer_class,
+        analyzer_options=opts,
+    )
+
+    # Assert — analyzer_options is the one we passed (MDC), not internally constructed
+    assert sut.analyzer_options is opts
+    assert sut.analyzer_options.redis_url == "redis://mdc:6379/0"
+    # WDC redis_url is separate
+    assert sut.redis_url == "redis://wdc:6379/1"
+
+
+def test_mdp_init_with_analyzer_options_expect_no_massive_api_key_param(
+    mock_meter, mock_setup_logging, mock_analyzer_class
+):
+    """massive_api_key must NOT be a top-level constructor param; it lives in AnalyzerOptions."""
+    from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
+    import inspect
+
+    sig = inspect.signature(MassiveDataProcessor.__init__)
+    assert "massive_api_key" not in sig.parameters, (
+        "massive_api_key should be in AnalyzerOptions, not MassiveDataProcessor.__init__"
+    )
+    assert "analyzer_options" in sig.parameters
+
+
+def test_mdp_init_with_analyzer_options_expect_analyzer_class_before_options(
+    mock_meter, mock_setup_logging, mock_analyzer_class
+):
+    """Parameter order must be: redis_url, analyzer_class, analyzer_options."""
+    import inspect
+
+    sig = inspect.signature(MassiveDataProcessor.__init__)
+    params = list(sig.parameters.keys())
+    redis_idx = params.index("redis_url")
+    cls_idx = params.index("analyzer_class")
+    opts_idx = params.index("analyzer_options")
+    assert redis_idx < cls_idx < opts_idx, (
+        f"Expected redis_url < analyzer_class < analyzer_options, got positions "
+        f"{redis_idx} < {cls_idx} < {opts_idx}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mdp_start_uses_analyzer_options_for_analyzer_instantiation(
+    mock_meter, mock_setup_logging, mock_analyzer_class
+):
+    """On start(), the analyzer must be instantiated with the provided analyzer_options."""
+    from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
+
+    opts = AnalyzerOptions(redis_url="redis://mdc:6379/0", massive_api_key="mdc-key")
+    sut = MassiveDataProcessor(
+        rabbitmq_url="amqp://localhost/",
+        queue_name="q",
+        redis_url="redis://wdc:6379/1",
+        analyzer_class=mock_analyzer_class,
+        analyzer_options=opts,
+    )
+
+    mock_queue = AsyncMock()
+    mock_queue.consume = AsyncMock()
+
+    with patch.object(sut, "connect", new_callable=AsyncMock), \
+         patch.object(sut, "stop", new_callable=AsyncMock), \
+         patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()]):
+        sut.mdc_connected = True
+        sut.mdq_connected = True
+        sut.rmq_channel = MagicMock()
+        sut.rmq_channel.get_queue = AsyncMock(return_value=mock_queue)
+
+        try:
+            await sut.start()
+        except asyncio.CancelledError:
+            pass
+
+    # Assert — analyzer instantiated with our analyzer_options
+    mock_analyzer_class.assert_called_once_with(options=opts)

--- a/tests/components/test_massive_data_processor.py
+++ b/tests/components/test_massive_data_processor.py
@@ -48,12 +48,14 @@ def mock_analyzer_class():
 
 @pytest.fixture
 def sut(mock_meter, mock_setup_logging, mock_analyzer_class):
+    from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
+    opts = AnalyzerOptions(redis_url="redis://mdc:6379/0", massive_api_key="test_key")
     return MassiveDataProcessor(
         rabbitmq_url="amqp://guest:guest@localhost/",
         queue_name="test_queue",
-        redis_url="redis://localhost",
-        massive_api_key="test_key",
+        redis_url="redis://wdc:6379/1",
         analyzer_class=mock_analyzer_class,
+        analyzer_options=opts,
         prefetch_count=50,
         max_concurrent_tasks=100,
     )
@@ -66,12 +68,14 @@ def test_mdp_init_with_valid_params_expect_attrs_set(
     mock_meter, mock_setup_logging, mock_analyzer_class
 ):
     # Arrange / Act
+    from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
+    opts = AnalyzerOptions(redis_url="redis://mdc:6379/0", massive_api_key="key1")
     sut = MassiveDataProcessor(
         rabbitmq_url="amqp://localhost/",
         queue_name="q1",
-        redis_url="redis://localhost",
-        massive_api_key="key1",
+        redis_url="redis://wdc:6379/1",
         analyzer_class=mock_analyzer_class,
+        analyzer_options=opts,
         prefetch_count=10,
         max_concurrent_tasks=20,
     )
@@ -79,8 +83,8 @@ def test_mdp_init_with_valid_params_expect_attrs_set(
     # Assert
     assert sut.rabbitmq_url == "amqp://localhost/"
     assert sut.queue_name == "q1"
-    assert sut.redis_url == "redis://localhost"
-    assert sut.massive_api_key == "key1"
+    assert sut.redis_url == "redis://wdc:6379/1"
+    assert sut.analyzer_options.massive_api_key == "key1"
     assert sut.prefetch_count == 10
     assert sut.max_concurrent_tasks == 20
     assert sut.processed == 0
@@ -100,12 +104,14 @@ def test_mdp_init_with_defaults_expect_default_concurrency(
     mock_meter, mock_setup_logging, mock_analyzer_class
 ):
     # Arrange / Act
+    from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
+    opts = AnalyzerOptions(redis_url="redis://mdc:6379/0", massive_api_key="key1")
     sut = MassiveDataProcessor(
         rabbitmq_url="amqp://localhost/",
         queue_name="q1",
-        redis_url="redis://localhost",
-        massive_api_key="key1",
+        redis_url="redis://wdc:6379/1",
         analyzer_class=mock_analyzer_class,
+        analyzer_options=opts,
     )
 
     # Assert


### PR DESCRIPTION
Fixes #68.

**Commit 1 (tests):** 4 failing tests.
**Commit 2 (impl):** Implementation making all tests pass.

Removes `massive_api_key` as a top-level constructor param; callers must now pass a pre-built `AnalyzerOptions` instance (MDC). The `redis_url` param remains but now represents the WDC connection for result storage.

New signature: `__init__(self, rabbitmq_url, queue_name, redis_url, analyzer_class, analyzer_options, ...)`