### PR TITLE
feat: introduce WidgetDataCacheKeys and WidgetDataCacheTTL enums (WDC/MDC enum split)

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/finlight_data_analyzer.py
@@ -4,9 +4,9 @@ Processes articles from the Finlight WebSocket feed (via FinlightDataProcessor)
 and publishes them to Redis for real-time distribution to WDS clients.
 
 Publishing strategy:
-- All articles → MarketDataPubSubKeys.NEWS_FEED_LATEST (news:feed:latest)
-- Enhanced articles → MarketDataPubSubKeys.NEWS_TICKER per US-listed company
-- Raw articles → MarketDataPubSubKeys.NEWS_TICKER for tickers parsed from title/summary
+- All articles → WidgetDataCacheKeys.NEWS_FEED_LATEST (news:feed:latest)
+- Enhanced articles → WidgetDataCacheKeys.NEWS_TICKER per US-listed company
+- Raw articles → WidgetDataCacheKeys.NEWS_TICKER for tickers parsed from title/summary
 
 US exchange codes (MIC):
 - XNYS → NYSE
@@ -19,10 +19,10 @@ from typing import Optional, List
 
 from kuhl_haus.mdp.analyzers.analyzer import Analyzer, AnalyzerOptions
 from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
-from kuhl_haus.mdp.enum.market_data_cache_ttl import MarketDataCacheTTL
-from kuhl_haus.mdp.enum.market_data_pubsub_keys import MarketDataPubSubKeys
-from kuhl_haus.mdp.enum.finlight_data_cache import FinlightDataCache
+from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
 
+from kuhl_haus.mdp.enum.finlight_data_cache import FinlightDataCache
 
 class FinlightDataAnalyzer(Analyzer):
     """Stateless analyzer that routes Finlight news articles to Redis pub/sub.
@@ -58,10 +58,10 @@ class FinlightDataAnalyzer(Analyzer):
 
         # Cache TTLs — default to enum values, overridable via AnalyzerOptions.kwargs
         self.news_feed_cache_ttl: int = options.kwargs.get(
-            "news_feed_cache_ttl", MarketDataCacheTTL.NEWS_FEED_LATEST.value
+            "news_feed_cache_ttl", WidgetDataCacheTTL.NEWS_FEED_LATEST.value
         )
         self.news_ticker_cache_ttl: int = options.kwargs.get(
-            "news_ticker_cache_ttl", MarketDataCacheTTL.NEWS_TICKER.value
+            "news_ticker_cache_ttl", WidgetDataCacheTTL.NEWS_TICKER.value
         )
 
     async def rehydrate(self):
@@ -83,9 +83,9 @@ class FinlightDataAnalyzer(Analyzer):
 
         results: List[MarketDataAnalyzerResult] = [MarketDataAnalyzerResult(
             data=data,
-            cache_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
+            cache_key=WidgetDataCacheKeys.NEWS_FEED_LATEST.value,
             cache_ttl=self.news_feed_cache_ttl,
-            publish_key=MarketDataPubSubKeys.NEWS_FEED_LATEST.value,
+            publish_key=WidgetDataCacheKeys.NEWS_FEED_LATEST.value,
             cache_list_max=self.news_feed_list_max,
         )]
 
@@ -103,9 +103,9 @@ class FinlightDataAnalyzer(Analyzer):
         for ticker in tickers:
             results.append(MarketDataAnalyzerResult(
                 data=data,
-                cache_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
+                cache_key=WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker=ticker),
                 cache_ttl=self.news_ticker_cache_ttl,
-                publish_key=MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker=ticker),
+                publish_key=WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker=ticker),
                 cache_list_max=self.news_ticker_list_max,
             ))
 

--- a/src/kuhl_haus/mdp/analyzers/leaderboard_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/leaderboard_analyzer.py
@@ -14,12 +14,13 @@ from kuhl_haus.mdp.components.market_data_cache import MarketDataCache
 from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
 from kuhl_haus.mdp.enum.market_data_cache_keys import MarketDataCacheKeys
 from kuhl_haus.mdp.enum.market_data_cache_ttl import MarketDataCacheTTL
-from kuhl_haus.mdp.enum.market_data_pubsub_keys import MarketDataPubSubKeys
+from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
+
 from kuhl_haus.mdp.exceptions.data_analysis_exception import DataAnalysisException
 from kuhl_haus.mdp.helpers.observability import get_tracer, get_meter
 
 tracer = get_tracer(__name__)
-
 
 class LeaderboardAnalyzer(Analyzer):
     """Redis-backed leaderboard analyzer using Sorted Sets.
@@ -93,9 +94,9 @@ class LeaderboardAnalyzer(Analyzer):
             if symbol_data:
                 quote_result = MarketDataAnalyzerResult(
                     data=symbol_data,
-                    cache_key=f"{MarketDataPubSubKeys.QUOTE.value}:{symbol}",
-                    cache_ttl=MarketDataCacheTTL.QUOTE.value,
-                    publish_key=f"{MarketDataPubSubKeys.QUOTE.value}:{symbol}",
+                    cache_key=f"{WidgetDataCacheKeys.QUOTE.value}:{symbol}",
+                    cache_ttl=WidgetDataCacheTTL.QUOTE.value,
+                    publish_key=f"{WidgetDataCacheKeys.QUOTE.value}:{symbol}",
                 )
 
             # Throttled leaderboard publish (only one instance publishes per second)
@@ -236,27 +237,27 @@ class LeaderboardAnalyzer(Analyzer):
         if leaderboards["top_volume"]:
             results.append(MarketDataAnalyzerResult(
                 data=leaderboards["top_volume"],
-                cache_key=MarketDataPubSubKeys.TOP_VOLUME_SCANNER.value,
-                cache_ttl=MarketDataCacheTTL.TOP_VOLUME_SCANNER.value,
-                publish_key=MarketDataPubSubKeys.TOP_VOLUME_SCANNER.value,
+                cache_key=WidgetDataCacheKeys.TOP_VOLUME_SCANNER.value,
+                cache_ttl=WidgetDataCacheTTL.TOP_VOLUME_SCANNER.value,
+                publish_key=WidgetDataCacheKeys.TOP_VOLUME_SCANNER.value,
             ))
 
         # Top Gappers
         if leaderboards["top_gappers"]:
             results.append(MarketDataAnalyzerResult(
                 data=leaderboards["top_gappers"],
-                cache_key=MarketDataPubSubKeys.TOP_GAPPERS_SCANNER.value,
-                cache_ttl=MarketDataCacheTTL.TOP_GAPPERS_SCANNER.value,
-                publish_key=MarketDataPubSubKeys.TOP_GAPPERS_SCANNER.value,
+                cache_key=WidgetDataCacheKeys.TOP_GAPPERS_SCANNER.value,
+                cache_ttl=WidgetDataCacheTTL.TOP_GAPPERS_SCANNER.value,
+                publish_key=WidgetDataCacheKeys.TOP_GAPPERS_SCANNER.value,
             ))
 
         # Top Gainers
         if leaderboards["top_gainers"]:
             results.append(MarketDataAnalyzerResult(
                 data=leaderboards["top_gainers"],
-                cache_key=MarketDataPubSubKeys.TOP_GAINERS_SCANNER.value,
-                cache_ttl=MarketDataCacheTTL.TOP_GAINERS_SCANNER.value,
-                publish_key=MarketDataPubSubKeys.TOP_GAINERS_SCANNER.value,
+                cache_key=WidgetDataCacheKeys.TOP_GAINERS_SCANNER.value,
+                cache_ttl=WidgetDataCacheTTL.TOP_GAINERS_SCANNER.value,
+                publish_key=WidgetDataCacheKeys.TOP_GAINERS_SCANNER.value,
 
             ))
 

--- a/src/kuhl_haus/mdp/analyzers/top_stocks.py
+++ b/src/kuhl_haus/mdp/analyzers/top_stocks.py
@@ -20,10 +20,8 @@ from kuhl_haus.mdp.analyzers.analyzer import Analyzer, AnalyzerOptions
 from kuhl_haus.mdp.components.market_data_cache import MarketDataCache
 from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
 from kuhl_haus.mdp.data.top_stocks_cache_item import TopStocksCacheItem
-from kuhl_haus.mdp.enum.market_data_cache_keys import MarketDataCacheKeys
-from kuhl_haus.mdp.enum.market_data_cache_ttl import MarketDataCacheTTL
-from kuhl_haus.mdp.enum.market_data_pubsub_keys import MarketDataPubSubKeys
-
+from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
 
 class TopStocksAnalyzer(Analyzer):
     """In-memory leaderboard analyzer (single-instance).
@@ -44,7 +42,7 @@ class TopStocksAnalyzer(Analyzer):
             rest_client=self.rest_client,
             redis_client=self.redis_client,
         )
-        self.cache_key = MarketDataCacheKeys.TOP_STOCKS_SCANNER.value
+        self.cache_key = WidgetDataCacheKeys.TOP_STOCKS_SCANNER.value
         self.logger = logging.getLogger(__name__)
         self.cache_item = TopStocksCacheItem()
         self.last_update_time = 0
@@ -126,25 +124,25 @@ class TopStocksAnalyzer(Analyzer):
             MarketDataAnalyzerResult(
                 data=self.cache_item.to_dict(),
                 cache_key=self.cache_key,
-                cache_ttl=MarketDataCacheTTL.TOP_STOCKS_SCANNER.value,
+                cache_ttl=WidgetDataCacheTTL.TOP_STOCKS_SCANNER.value,
             ),
             MarketDataAnalyzerResult(
                 data=self.cache_item.top_volume(500),
-                cache_key=MarketDataPubSubKeys.TOP_VOLUME_SCANNER.value,
-                cache_ttl=MarketDataCacheTTL.TOP_VOLUME_SCANNER.value,
-                publish_key=MarketDataPubSubKeys.TOP_VOLUME_SCANNER.value,
+                cache_key=WidgetDataCacheKeys.TOP_VOLUME_SCANNER.value,
+                cache_ttl=WidgetDataCacheTTL.TOP_VOLUME_SCANNER.value,
+                publish_key=WidgetDataCacheKeys.TOP_VOLUME_SCANNER.value,
             ),
             MarketDataAnalyzerResult(
                 data=self.cache_item.top_gainers(500),
-                cache_key=MarketDataPubSubKeys.TOP_GAINERS_SCANNER.value,
-                cache_ttl=MarketDataCacheTTL.TOP_GAINERS_SCANNER.value,
-                publish_key=MarketDataPubSubKeys.TOP_GAINERS_SCANNER.value,
+                cache_key=WidgetDataCacheKeys.TOP_GAINERS_SCANNER.value,
+                cache_ttl=WidgetDataCacheTTL.TOP_GAINERS_SCANNER.value,
+                publish_key=WidgetDataCacheKeys.TOP_GAINERS_SCANNER.value,
             ),
             MarketDataAnalyzerResult(
                 data=self.cache_item.top_gappers(500),
-                cache_key=MarketDataPubSubKeys.TOP_GAPPERS_SCANNER.value,
-                cache_ttl=MarketDataCacheTTL.TOP_GAPPERS_SCANNER.value,
-                publish_key=MarketDataPubSubKeys.TOP_GAPPERS_SCANNER.value,
+                cache_key=WidgetDataCacheKeys.TOP_GAPPERS_SCANNER.value,
+                cache_ttl=WidgetDataCacheTTL.TOP_GAPPERS_SCANNER.value,
+                publish_key=WidgetDataCacheKeys.TOP_GAPPERS_SCANNER.value,
             )
         ]
 

--- a/src/kuhl_haus/mdp/analyzers/top_trades_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/top_trades_analyzer.py
@@ -14,11 +14,12 @@ from kuhl_haus.mdp.analyzers.analyzer import Analyzer, AnalyzerOptions
 from kuhl_haus.mdp.components.market_data_cache import MarketDataCache
 from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
 from kuhl_haus.mdp.enum.market_data_cache_keys import MarketDataCacheKeys
+from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
 from kuhl_haus.mdp.enum.market_data_cache_ttl import MarketDataCacheTTL
+from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
 from kuhl_haus.mdp.helpers.observability import get_tracer, get_meter
 
 tracer = get_tracer(__name__)
-
 
 class TopTradesAnalyzer(Analyzer):
     """Redis-backed trade analyzer using Lists for time-series data.
@@ -38,10 +39,10 @@ class TopTradesAnalyzer(Analyzer):
     PUBLISH_THROTTLE_KEY = MarketDataCacheKeys.TOP_TRADES_LAST_PUBLISH_KEY.value
     TRADE_TTL = MarketDataCacheTTL.TOP_TRADES_TRADE_TTL.value
 
-    TOP_TRADES_ALL_SYMBOLS_CACHE_KEY = MarketDataCacheKeys.TOP_TRADES_ALL_SYMBOLS_CACHE_KEY.value
+    TOP_TRADES_ALL_SYMBOLS_CACHE_KEY = WidgetDataCacheKeys.TOP_TRADES_ALL_SYMBOLS_CACHE_KEY.value
     TOP_TRADES_ALL_SYMBOLS_CACHE_TTL = MarketDataCacheTTL.TOP_TRADES_ALL_SYMBOLS_CACHE_TTL.value
 
-    TOP_TRADES_WIDGET_CACHE_KEY = MarketDataCacheKeys.TOP_TRADES_WIDGET_CACHE_KEY.value
+    TOP_TRADES_WIDGET_CACHE_KEY = WidgetDataCacheKeys.TOP_TRADES_WIDGET_CACHE_KEY.value
     TOP_TRADES_WIDGET_CACHE_TTL = MarketDataCacheTTL.TOP_TRADES_WIDGET_CACHE_TTL.value
 
     # Configuration

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_keys.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_keys.py
@@ -1,0 +1,43 @@
+"""Redis key and channel names for the Widget Data Cache (WDC).
+
+All keys written by Analyzers/Processors and read by the Widget Data Service
+for real-time widget delivery. Replaces MarketDataPubSubKeys and consolidates
+WDC-facing keys from MarketDataCacheKeys.
+"""
+from enum import Enum
+
+from kuhl_haus.mdp.enum.market_data_scanner_names import MarketDataScannerNames
+
+
+class WidgetDataCacheKeys(Enum):
+    """Redis key identifiers for Widget Data Cache entries.
+
+    Published by MDP analyzers after processing real-time market data. Widget
+    Data Service subscribes to forward results to frontend clients. Multiple
+    time windows available for Top Trades to support different UI refresh rates.
+    """
+    # Top Trades Scanner channels
+    TOP_10_LISTS_SCANNER = 'scanners:top_10_lists'
+    TOP_TRADES_SCANNER_ONE_HOUR = f'scanners:{MarketDataScannerNames.TOP_TRADES.value}:1h'
+    TOP_TRADES_SCANNER_FIVE_MINUTES = f'scanners:{MarketDataScannerNames.TOP_TRADES.value}:5m'
+    TOP_TRADES_SCANNER_ONE_MINUTE = f'scanners:{MarketDataScannerNames.TOP_TRADES.value}:1m'
+
+    # Top Trades widget cache keys (formerly MarketDataCacheKeys)
+    TOP_TRADES_WIDGET_CACHE_KEY = "tta:{symbol}:widget"
+    TOP_TRADES_ALL_SYMBOLS_CACHE_KEY = "tta:all_symbols:widget"
+
+    # Per-symbol quote feed
+    QUOTE = 'quote'  # Usage: f'{QUOTE.value}:{symbol}'
+
+    # Single-feed scanner channels
+    TOP_GAINERS_SCANNER = f'scanners:{MarketDataScannerNames.TOP_GAINERS.value}'
+    TOP_GAPPERS_SCANNER = f'scanners:{MarketDataScannerNames.TOP_GAPPERS.value}'
+    TOP_VOLUME_SCANNER = f'scanners:{MarketDataScannerNames.TOP_VOLUME.value}'
+
+    # Scanner result cache keys (formerly MarketDataCacheKeys)
+    TOP_TRADES_SCANNER = f'cache:{MarketDataScannerNames.TOP_TRADES.value}'
+    TOP_STOCKS_SCANNER = f'cache:{MarketDataScannerNames.TOP_STOCKS.value}'
+
+    # Finlight news feeds
+    NEWS_FEED_LATEST = 'news:feed:latest'
+    NEWS_TICKER = 'news:ticker:{ticker}'

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
@@ -1,0 +1,38 @@
+"""Redis TTL values for Widget Data Cache (WDC) entries.
+
+Defines expiration times for all widget-facing cached data. These TTLs govern
+how long Processor/Analyzer results remain available in the WDC for widget
+consumption. Separated from MarketDataCacheTTL which governs internal MDC data.
+"""
+from enum import Enum
+
+from kuhl_haus.mdp.enum.constants import (
+    FOUR_DAYS,
+    ONE_MINUTE,
+    SEVEN_DAYS,
+    TWO_DAYS,
+)
+
+
+class WidgetDataCacheTTL(Enum):
+    """Time-to-live durations for Widget Data Cache entries.
+
+    Covers scanner results, quote feeds, and news feeds — all data written
+    by Analyzers and consumed by the Widget Data Service.
+    """
+    # Quote feed
+    QUOTE = FOUR_DAYS  # Stale data > no data; timestamp in payload shows freshness
+
+    # Scanner caches
+    TOP_STOCKS_SCANNER = FOUR_DAYS
+    TOP_VOLUME_SCANNER = FOUR_DAYS
+    TOP_GAINERS_SCANNER = FOUR_DAYS
+    TOP_GAPPERS_SCANNER = FOUR_DAYS
+
+    # Top Trades widget caches
+    TOP_TRADES_WIDGET_CACHE_TTL = ONE_MINUTE
+    TOP_TRADES_ALL_SYMBOLS_CACHE_TTL = ONE_MINUTE
+
+    # Finlight news caches
+    NEWS_FEED_LATEST = TWO_DAYS
+    NEWS_TICKER = SEVEN_DAYS

--- a/tests/test_widget_data_cache_enums.py
+++ b/tests/test_widget_data_cache_enums.py
@@ -1,0 +1,159 @@
+"""Tests for WidgetDataCacheKeys and WidgetDataCacheTTL enums.
+
+Proves:
+1. WidgetDataCacheKeys exists and contains all expected WDC keys
+   (formerly MarketDataPubSubKeys + WDC keys from MarketDataCacheKeys)
+2. WidgetDataCacheTTL exists and contains all expected WDC TTLs
+   (formerly in MarketDataCacheTTL)
+3. All analyzers use the new enums, not the old ones
+
+refs #70
+"""
+import pytest
+
+
+# ── WidgetDataCacheKeys ────────────────────────────────────────────────────────
+
+
+def test_widget_data_cache_keys_module_exists():
+    """WidgetDataCacheKeys enum must be importable."""
+    from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+    assert WidgetDataCacheKeys is not None
+
+
+def test_widget_data_cache_keys_has_quote():
+    from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+    assert WidgetDataCacheKeys.QUOTE.value == "quote"
+
+
+def test_widget_data_cache_keys_has_news_feed_latest():
+    from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+    assert WidgetDataCacheKeys.NEWS_FEED_LATEST.value == "news:feed:latest"
+
+
+def test_widget_data_cache_keys_has_news_ticker():
+    from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+    assert WidgetDataCacheKeys.NEWS_TICKER.value == "news:ticker:{ticker}"
+
+
+def test_widget_data_cache_keys_has_scanner_keys():
+    from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+    assert hasattr(WidgetDataCacheKeys, "TOP_VOLUME_SCANNER")
+    assert hasattr(WidgetDataCacheKeys, "TOP_GAINERS_SCANNER")
+    assert hasattr(WidgetDataCacheKeys, "TOP_GAPPERS_SCANNER")
+    assert hasattr(WidgetDataCacheKeys, "TOP_STOCKS_SCANNER")
+    assert hasattr(WidgetDataCacheKeys, "TOP_TRADES_SCANNER_ONE_MINUTE")
+    assert hasattr(WidgetDataCacheKeys, "TOP_TRADES_SCANNER_FIVE_MINUTES")
+    assert hasattr(WidgetDataCacheKeys, "TOP_TRADES_SCANNER_ONE_HOUR")
+
+
+def test_widget_data_cache_keys_has_top_trades_cache_keys():
+    from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+    assert hasattr(WidgetDataCacheKeys, "TOP_TRADES_WIDGET_CACHE_KEY")
+    assert hasattr(WidgetDataCacheKeys, "TOP_TRADES_ALL_SYMBOLS_CACHE_KEY")
+    assert hasattr(WidgetDataCacheKeys, "TOP_10_LISTS_SCANNER")
+
+
+# ── WidgetDataCacheTTL ────────────────────────────────────────────────────────
+
+
+def test_widget_data_cache_ttl_module_exists():
+    """WidgetDataCacheTTL enum must be importable."""
+    from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
+    assert WidgetDataCacheTTL is not None
+
+
+def test_widget_data_cache_ttl_has_quote():
+    from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
+    from kuhl_haus.mdp.enum.market_data_cache_ttl import MarketDataCacheTTL
+    assert WidgetDataCacheTTL.QUOTE.value == MarketDataCacheTTL.QUOTE.value
+
+
+def test_widget_data_cache_ttl_has_scanner_ttls():
+    from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
+    assert hasattr(WidgetDataCacheTTL, "TOP_STOCKS_SCANNER")
+    assert hasattr(WidgetDataCacheTTL, "TOP_VOLUME_SCANNER")
+    assert hasattr(WidgetDataCacheTTL, "TOP_GAINERS_SCANNER")
+    assert hasattr(WidgetDataCacheTTL, "TOP_GAPPERS_SCANNER")
+
+
+def test_widget_data_cache_ttl_has_top_trades_ttls():
+    from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
+    assert hasattr(WidgetDataCacheTTL, "TOP_TRADES_WIDGET_CACHE_TTL")
+    assert hasattr(WidgetDataCacheTTL, "TOP_TRADES_ALL_SYMBOLS_CACHE_TTL")
+
+
+def test_widget_data_cache_ttl_has_news_ttls():
+    from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
+    assert hasattr(WidgetDataCacheTTL, "NEWS_FEED_LATEST")
+    assert hasattr(WidgetDataCacheTTL, "NEWS_TICKER")
+
+
+# ── Analyzer usages ───────────────────────────────────────────────────────────
+
+
+def test_leaderboard_analyzer_imports_widget_data_cache_keys():
+    """LeaderboardAnalyzer must import from WidgetDataCacheKeys."""
+    import ast, inspect
+    import kuhl_haus.mdp.analyzers.leaderboard_analyzer as mod
+    src = inspect.getsource(mod)
+    assert "WidgetDataCacheKeys" in src
+    assert "MarketDataPubSubKeys" not in src
+
+
+def test_leaderboard_analyzer_imports_widget_data_cache_ttl():
+    """LeaderboardAnalyzer must import from WidgetDataCacheTTL."""
+    import inspect
+    import kuhl_haus.mdp.analyzers.leaderboard_analyzer as mod
+    src = inspect.getsource(mod)
+    assert "WidgetDataCacheTTL" in src
+
+
+def test_finlight_data_analyzer_imports_widget_data_cache_keys():
+    """FinlightDataAnalyzer must import from WidgetDataCacheKeys."""
+    import inspect
+    import kuhl_haus.mdp.analyzers.finlight_data_analyzer as mod
+    src = inspect.getsource(mod)
+    assert "WidgetDataCacheKeys" in src
+    assert "MarketDataPubSubKeys" not in src
+
+
+def test_finlight_data_analyzer_imports_widget_data_cache_ttl():
+    """FinlightDataAnalyzer must import from WidgetDataCacheTTL."""
+    import inspect
+    import kuhl_haus.mdp.analyzers.finlight_data_analyzer as mod
+    src = inspect.getsource(mod)
+    assert "WidgetDataCacheTTL" in src
+
+
+def test_top_stocks_analyzer_imports_widget_data_cache_keys():
+    """TopStocksAnalyzer must import from WidgetDataCacheKeys."""
+    import inspect
+    import kuhl_haus.mdp.analyzers.top_stocks as mod
+    src = inspect.getsource(mod)
+    assert "WidgetDataCacheKeys" in src
+    assert "MarketDataPubSubKeys" not in src
+
+
+def test_top_stocks_analyzer_imports_widget_data_cache_ttl():
+    """TopStocksAnalyzer must import from WidgetDataCacheTTL."""
+    import inspect
+    import kuhl_haus.mdp.analyzers.top_stocks as mod
+    src = inspect.getsource(mod)
+    assert "WidgetDataCacheTTL" in src
+
+
+def test_top_trades_analyzer_imports_widget_data_cache_keys():
+    """TopTradesAnalyzer must import from WidgetDataCacheKeys."""
+    import inspect
+    import kuhl_haus.mdp.analyzers.top_trades_analyzer as mod
+    src = inspect.getsource(mod)
+    assert "WidgetDataCacheKeys" in src
+
+
+def test_top_trades_analyzer_imports_widget_data_cache_ttl():
+    """TopTradesAnalyzer must import from WidgetDataCacheTTL."""
+    import inspect
+    import kuhl_haus.mdp.analyzers.top_trades_analyzer as mod
+    src = inspect.getsource(mod)
+    assert "WidgetDataCacheTTL" in src


### PR DESCRIPTION
Fixes #70.

**Commit 1 (tests):** 19 failing tests.
**Commit 2 (impl):** Implementation making all tests pass.

Changes:
- New `widget_data_cache_keys.py` — `WidgetDataCacheKeys` enum (all WDC-facing keys)
- New `widget_data_cache_ttl.py` — `WidgetDataCacheTTL` enum (all WDC-facing TTLs)
- `MarketDataPubSubKeys` kept for backward compat (external consumers)
- WDC entries removed from `MarketDataCacheKeys` and `MarketDataCacheTTL`
- All 4 affected analyzers updated to use new enums