### PR TITLE
docs: add MDS component + WDC section; update enum refs for v0.4.0

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -31,8 +31,14 @@ Data Plane Components
 **Market Data Processor (MDP)**
   Horizontally-scalable event processors with semaphore-based concurrency (500 concurrent tasks), delegating to pluggable analyzers.
 
+**Market Data Scanner (MDS)**
+  Redis pub/sub consumer that performs secondary analysis on enriched market data — event correlation, alert generation, trend analysis, and pattern recognition — through pluggable analyzers.
+
 **Market Data Cache (MDC)**
-  Redis-backed cache layer with TTL policies (5s-24h), atomic operations, and pub/sub distribution.
+  Internal Redis store for analyzer state with TTL policies (5s-24h), atomic operations, and pub/sub distribution. Separate from WDC.
+
+**Widget Data Cache (WDC)**
+  Client-facing Redis store for widget-ready results (scanner feeds, quotes, news) with TTL policies optimized for UI consumption. Separate from MDC.
 
 **Widget Data Service (WDS)**
   WebSocket-to-Redis bridge providing real-time streaming to client applications with fan-out pattern.
@@ -53,7 +59,7 @@ Deployment Model
 
 The platform deploys to Kubernetes with independent scaling per component:
 
-- **Data plane**: Internal network only (MDL, MDQ, MDP, MDC)
+- **Data plane**: Internal network only (MDL, MDQ, MDP, MDS, MDC, WDC)
 - **Client interface**: Exposed to client networks (WDS)
 - **Control plane**: External access (SCP)
 
@@ -149,7 +155,6 @@ Code Libraries
 ~~~~~~~~~~~~~~
 
 - **MassiveDataProcessor** (`components/massive_data_processor.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.components.html#module-kuhl_haus.mdp.components.massive_data_processor>`_) - RabbitMQ consumer with semaphore-based concurrency control for high-throughput scenarios (1,000+ events/sec)
-- **MarketDataScanner** (`components/market_data_scanner.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.components.html#module-kuhl_haus.mdp.components.market_data_scanner>`_) - Redis pub/sub consumer with pluggable analyzer pattern for sequential message processing
 - **Analyzers** (`analyzers/ <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.analyzers.html>`_)
 
   - **MassiveDataAnalyzer** (`massive_data_analyzer.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.analyzers.html#module-kuhl_haus.mdp.analyzers.massive_data_analyzer>`_) - Stateless event router dispatching by event type
@@ -160,14 +165,41 @@ Code Libraries
 - **MarketDataAnalyzerResult** (`data/market_data_analyzer_result.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.data.html#module-kuhl_haus.mdp.data.market_data_analyzer_result>`_) - Result envelope for analyzer output with cache/publish metadata
 - **ProcessManager** (`helpers/process_manager.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.helpers.html#module-kuhl_haus.mdp.helpers.process_manager>`_) - Multiprocess orchestration for async workers with OpenTelemetry context propagation
 
+Market Data Scanner (MDS)
+--------------------------
+
+The MDS performs secondary analysis on enriched market data already processed and published by MDPs. Unlike the MDP (which consumes raw RabbitMQ streams), the MDS subscribes directly to Redis pub/sub channels to receive post-processed data. This makes the MDS a Redis-only component, suited for secondary processing tasks such as event correlation, alert generation, trend analysis, and pattern recognition.
+
+The MDS:
+
+- Subscribes to Redis pub/sub channels (including wildcard/pattern subscriptions)
+- Rehydrates analyzer state from the WDC cache on startup
+- Delegates messages to a pluggable Analyzer subclass
+- Writes results back to the Widget Data Cache (WDC) and publishes notifications
+
+MDS instances run as containers and scale independently of other components. The MDS should not be accessible outside the data plane local network.
+
+Code Libraries
+~~~~~~~~~~~~~~
+
+- **MarketDataScanner** (`components/market_data_scanner.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.components.html#module-kuhl_haus.mdp.components.market_data_scanner>`_) - Redis pub/sub consumer with pluggable analyzer pattern. Handles pattern/wildcard subscriptions, exponential-backoff idle polling (1s→60s cap), auto-restart on connection errors, and sequential message processing
+- **Analyzers** (`analyzers/ <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.analyzers.html>`_)
+
+  - **FinlightDataAnalyzer** (`finlight_data_analyzer.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.analyzers.html#module-kuhl_haus.mdp.analyzers.finlight_data_analyzer>`_) - Maintains capped news feed lists (``news:feed:latest``, ``news:ticker:{symbol}``) in WDC with configurable TTLs
+
+- **MarketDataAnalyzerResult** (`data/market_data_analyzer_result.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.data.html#module-kuhl_haus.mdp.data.market_data_analyzer_result>`_) - Result envelope for analyzer output with cache/publish metadata
+- **AnalyzerOptions** (`analyzers/analyzer.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.analyzers.html#module-kuhl_haus.mdp.analyzers.analyzer>`_) - Shared configuration container (``redis_url``, ``finlight_api_key``, ``massive_api_key``, ``kwargs`` escape hatch for subclass-specific config)
+- **WidgetDataCacheKeys** enum (`enum/widget_data_cache_keys.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.enum.html#module-kuhl_haus.mdp.enum.widget_data_cache_keys>`_) - WDC Redis key and channel name constants for all MDS-published data
+- **WidgetDataCacheTTL** enum (`enum/widget_data_cache_ttl.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.enum.html#module-kuhl_haus.mdp.enum.widget_data_cache_ttl>`_) - TTL values for WDC entries (quotes: 4 days, scanners: 4 days, news feed: 2 days, news ticker: 7 days)
+
 Market Data Cache (MDC)
 ------------------------
 
-**Purpose:** In-memory data store for serialized processed market data.
+**Purpose:** Internal Redis store for analyzer state and intermediate market data produced by MDP analyzers.
 
 - **Cache Type:** In-memory persistent or with TTL
 - **Queue Type:** pub/sub
-- **Technology:** Redis
+- **Technology:** Redis (separate instance from WDC)
 
 The MDC should not be accessible outside the data plane local network.
 
@@ -177,7 +209,26 @@ Code Libraries
 - **MarketDataCache** (`components/market_data_cache.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.components.html#module-kuhl_haus.mdp.components.market_data_cache>`_) - Redis cache-aside layer for Massive.com API with TTL policies, negative caching, and specialized metric methods (snapshot, avg volume, free float)
 - **MarketDataCacheKeys** enum (`enum/market_data_cache_keys.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.enum.html#module-kuhl_haus.mdp.enum.market_data_cache_keys>`_) - Internal Redis cache key patterns and templates
 - **MarketDataCacheTTL** enum (`enum/market_data_cache_ttl.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.enum.html#module-kuhl_haus.mdp.enum.market_data_cache_ttl>`_) - TTL values balancing freshness vs. API quotas vs. memory pressure (5s for trades, 24h for reference data)
-- **MarketDataPubSubKeys** enum (`enum/market_data_pubsub_keys.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.enum.html#module-kuhl_haus.mdp.enum.market_data_pubsub_keys>`_) - Redis pub/sub channel names for external consumption
+- **MarketDataPubSubKeys** enum (`enum/market_data_pubsub_keys.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.enum.html#module-kuhl_haus.mdp.enum.market_data_pubsub_keys>`_) - Redis pub/sub channel names (kept for backward compatibility; prefer ``WidgetDataCacheKeys`` for new work)
+
+Widget Data Cache (WDC)
+------------------------
+
+**Purpose:** Client-facing Redis store for widget-ready results produced by Analyzers and consumed by the Widget Data Service.
+
+- **Cache Type:** In-memory with TTL
+- **Queue Type:** pub/sub
+- **Technology:** Redis (separate instance from MDC)
+
+The WDC holds scanner feeds, quote feeds, and news feeds — all data that flows directly to UI widgets via WDS. Separating WDC from MDC isolates client-facing load from internal analyzer state.
+
+The WDC should not be accessible outside the data plane local network.
+
+Code Libraries
+~~~~~~~~~~~~~~
+
+- **WidgetDataCacheKeys** enum (`enum/widget_data_cache_keys.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.enum.html#module-kuhl_haus.mdp.enum.widget_data_cache_keys>`_) - Redis key and channel name constants for all WDC entries (scanner channels, quote feed, news feeds, top trades widget cache). Replaces ``MarketDataPubSubKeys`` for new work.
+- **WidgetDataCacheTTL** enum (`enum/widget_data_cache_ttl.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.enum.html#module-kuhl_haus.mdp.enum.widget_data_cache_ttl>`_) - TTL values for all WDC entries (quotes: 4 days, scanners: 4 days, news feed: 2 days, news ticker: 7 days)
 
 Widget Data Service (WDS)
 --------------------------
@@ -194,6 +245,7 @@ Code Libraries
 
 - **WidgetDataService** (`components/widget_data_service.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.components.html#module-kuhl_haus.mdp.components.widget_data_service>`_) - WebSocket-to-Redis bridge with fan-out pattern, lazy task initialization, wildcard subscription support, and lock-protected subscription management
 - **MarketDataCache** (`components/market_data_cache.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.components.html#module-kuhl_haus.mdp.components.market_data_cache>`_) - Snapshot retrieval for initial state before streaming
+- **WidgetDataCacheKeys** enum (`enum/widget_data_cache_keys.py <https://kuhl-haus-mdp.readthedocs.io/en/latest/mdp/kuhl_haus.mdp.enum.html#module-kuhl_haus.mdp.enum.widget_data_cache_keys>`_) - WDC channel names WDS subscribes to for forwarding results to clients
 
 Service Control Plane (SCP)
 ----------------------------

--- a/src/kuhl_haus/mdp/enum/market_data_cache_keys.py
+++ b/src/kuhl_haus/mdp/enum/market_data_cache_keys.py
@@ -3,7 +3,8 @@
 Defines all cache key templates used within MDP for storing raw WebSocket data,
 computed analytics, and rate-limiting state. Keys support pattern matching for
 bulk operations (e.g., TOP_TRADES_RECENT_SCAN for multi-symbol cleanup).
-These are internal keys; pub/sub channel names are in MarketDataPubSubKeys.
+These are internal MDC keys. For WDC-facing pub/sub and cache keys, use
+:class:`~kuhl_haus.mdp.enum.widget_data_cache_keys.WidgetDataCacheKeys`.
 """
 from enum import Enum
 
@@ -16,7 +17,10 @@ class MarketDataCacheKeys(Enum):
     Internal cache keys for MDP components. Includes both concrete keys and
     string templates with placeholders (e.g., {symbol}, {date}) for dynamic
     instantiation. Pattern-based keys ending in '*' enable SCAN operations for
-    bulk cleanup and inspection. Separate from pub/sub channel names.
+    bulk cleanup and inspection.
+
+    For WDC-facing pub/sub and cache keys (scanner channels, quote feed, news feeds),
+    use :class:`~kuhl_haus.mdp.enum.widget_data_cache_keys.WidgetDataCacheKeys` instead.
     """
 
     # MARKET DATA FEEDS

--- a/src/kuhl_haus/mdp/enum/market_data_cache_keys.py
+++ b/src/kuhl_haus/mdp/enum/market_data_cache_keys.py
@@ -5,6 +5,18 @@ computed analytics, and rate-limiting state. Keys support pattern matching for
 bulk operations (e.g., TOP_TRADES_RECENT_SCAN for multi-symbol cleanup).
 These are internal MDC keys. For WDC-facing pub/sub and cache keys, use
 :class:`~kuhl_haus.mdp.enum.widget_data_cache_keys.WidgetDataCacheKeys`.
+
+The following members are deprecated as of v0.4.0 and will be removed in the
+next minor release (no active usages found):
+
+- ``TOP_TRADES_WIDGET_CACHE_KEY``
+- ``TOP_TRADES_ALL_SYMBOLS_CACHE_KEY``
+- ``DAILY_AGGREGATES``
+- ``TOP_TRADES_SCANNER``
+- ``TOP_GAINERS_SCANNER``
+- ``TOP_GAPPERS_SCANNER``
+- ``TOP_STOCKS_SCANNER``
+- ``TOP_VOLUME_SCANNER``
 """
 from enum import Enum
 
@@ -21,6 +33,19 @@ class MarketDataCacheKeys(Enum):
 
     For WDC-facing pub/sub and cache keys (scanner channels, quote feed, news feeds),
     use :class:`~kuhl_haus.mdp.enum.widget_data_cache_keys.WidgetDataCacheKeys` instead.
+
+    .. deprecated::
+        The following members are deprecated as of v0.4.0 and will be removed in
+        the next minor release (no active usages found):
+
+        - ``TOP_TRADES_WIDGET_CACHE_KEY``
+        - ``TOP_TRADES_ALL_SYMBOLS_CACHE_KEY``
+        - ``DAILY_AGGREGATES``
+        - ``TOP_TRADES_SCANNER``
+        - ``TOP_GAINERS_SCANNER``
+        - ``TOP_GAPPERS_SCANNER``
+        - ``TOP_STOCKS_SCANNER``
+        - ``TOP_VOLUME_SCANNER``
     """
 
     # MARKET DATA FEEDS
@@ -43,11 +68,16 @@ class MarketDataCacheKeys(Enum):
     TOP_TRADES_RECENT_SCAN = "tta:*:recent"
     TOP_TRADES_STATS_PREFIX = "tta:{symbol}:stats"
     TOP_TRADES_LAST_PUBLISH_KEY = "tta:last_publish"
+
+    # --- Deprecated members (no active usages) ---
+
+    # @deprecated — no active usages; use WidgetDataCacheKeys.TOP_TRADES_WIDGET_CACHE_KEY
     TOP_TRADES_WIDGET_CACHE_KEY = "tta:{symbol}:widget"
+
+    # @deprecated — no active usages; use WidgetDataCacheKeys.TOP_TRADES_ALL_SYMBOLS_CACHE_KEY
     TOP_TRADES_ALL_SYMBOLS_CACHE_KEY = "tta:all_symbols:widget"
 
     # MARKET DATA CACHE
-    DAILY_AGGREGATES = 'mdc:aggregate:daily'
     TICKER_SNAPSHOTS = 'mdc:snapshots'
     TICKER_AVG_VOLUME = 'mdc:avg_volume'
     TICKER_FREE_FLOAT = 'mdc:free_float'
@@ -55,11 +85,19 @@ class MarketDataCacheKeys(Enum):
     TICKER_AVG_VOLUME_LOCK = 'mdc:lock:avg_volume'
     TICKER_FREE_FLOAT_LOCK = 'mdc:lock:free_float'
 
+    # @deprecated — no active usages
+    DAILY_AGGREGATES = 'mdc:aggregate:daily'
+
     # MARKET DATA PROCESSOR CACHE
+    # @deprecated — no active usages; use WidgetDataCacheKeys equivalents
     TOP_TRADES_SCANNER = f'cache:{MarketDataScannerNames.TOP_TRADES.value}'
+    # @deprecated — no active usages; use WidgetDataCacheKeys equivalents
     TOP_GAINERS_SCANNER = f'cache:{MarketDataScannerNames.TOP_GAINERS.value}'
+    # @deprecated — no active usages; use WidgetDataCacheKeys equivalents
     TOP_GAPPERS_SCANNER = f'cache:{MarketDataScannerNames.TOP_GAPPERS.value}'
+    # @deprecated — no active usages; use WidgetDataCacheKeys equivalents
     TOP_STOCKS_SCANNER = f'cache:{MarketDataScannerNames.TOP_STOCKS.value}'
+    # @deprecated — no active usages; use WidgetDataCacheKeys equivalents
     TOP_VOLUME_SCANNER = f'cache:{MarketDataScannerNames.TOP_VOLUME.value}'
 
     # NOT IMPLEMENTED FEEDS

--- a/src/kuhl_haus/mdp/enum/market_data_cache_ttl.py
+++ b/src/kuhl_haus/mdp/enum/market_data_cache_ttl.py
@@ -1,9 +1,26 @@
-"""Redis cache TTL values in seconds for market data artifacts.
+"""Redis cache TTL values in seconds for internal market data artifacts (MDC).
 
-Defines expiration times for all cached data types in the real-time pipeline.
-TTLs are tuned based on data volatility, API rate limits, and frontend refresh
-requirements. Shorter TTLs for high-frequency data, longer for reference data.
+Defines expiration times for all MDC-resident cached data types in the
+real-time pipeline. TTLs are tuned based on data volatility, API rate limits,
+and frontend refresh requirements. Shorter TTLs for high-frequency data,
+longer for reference data.
+
+For WDC-facing TTLs (scanner results, quote feed, news feeds), use
+:class:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL` instead.
+The following entries are deprecated as of v0.4.0 and will be removed in the
+next minor release:
+
+- ``QUOTE`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.QUOTE`
+- ``TOP_TRADES_WIDGET_CACHE_TTL`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_TRADES_WIDGET_CACHE_TTL`
+- ``TOP_TRADES_ALL_SYMBOLS_CACHE_TTL`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_TRADES_ALL_SYMBOLS_CACHE_TTL`
+- ``TOP_STOCKS_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_STOCKS_SCANNER`
+- ``TOP_VOLUME_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_VOLUME_SCANNER`
+- ``TOP_GAINERS_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_GAINERS_SCANNER`
+- ``TOP_GAPPERS_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_GAPPERS_SCANNER`
+- ``NEWS_FEED_LATEST`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.NEWS_FEED_LATEST`
+- ``NEWS_TICKER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.NEWS_TICKER`
 """
+import warnings
 from enum import Enum
 from kuhl_haus.mdp.enum.constants import (
     EIGHT_HOURS,
@@ -28,6 +45,22 @@ class MarketDataCacheTTL(Enum):
     pressure. High-velocity trade data expires quickly; reference data like
     float shares persists for hours. Negative cache prevents retry storms on
     API failures.
+
+    .. deprecated::
+        The following members are deprecated as of v0.4.0 and will be removed in
+        the next minor release. Use the corresponding
+        :class:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL`
+        members instead:
+
+        - ``QUOTE``
+        - ``TOP_TRADES_WIDGET_CACHE_TTL``
+        - ``TOP_TRADES_ALL_SYMBOLS_CACHE_TTL``
+        - ``TOP_STOCKS_SCANNER``
+        - ``TOP_VOLUME_SCANNER``
+        - ``TOP_GAINERS_SCANNER``
+        - ``TOP_GAPPERS_SCANNER``
+        - ``NEWS_FEED_LATEST``
+        - ``NEWS_TICKER``
     """
     # Negative Cache TTLs
     NEGATIVE_CACHE_THROTTLE = ONE_MINUTE
@@ -56,18 +89,61 @@ class MarketDataCacheTTL(Enum):
 
     # Top Trades caches
     TOP_TRADES_TRADE_TTL = FIVE_MINUTES
+
+    # --- Deprecated WDC entries (use WidgetDataCacheTTL) ---
+
+    # @deprecated Use WidgetDataCacheTTL.TOP_TRADES_WIDGET_CACHE_TTL
     TOP_TRADES_WIDGET_CACHE_TTL = ONE_MINUTE
+
+    # @deprecated Use WidgetDataCacheTTL.TOP_TRADES_ALL_SYMBOLS_CACHE_TTL
     TOP_TRADES_ALL_SYMBOLS_CACHE_TTL = ONE_MINUTE
 
-    # Quote feed cache
-    QUOTE = FOUR_DAYS  # Stale data > no data; timestamp in payload shows freshness
+    # @deprecated Use WidgetDataCacheTTL.QUOTE
+    QUOTE = FOUR_DAYS
 
-    # Scanner caches
+    # @deprecated Use WidgetDataCacheTTL.TOP_STOCKS_SCANNER
     TOP_STOCKS_SCANNER = EIGHT_HOURS
+
+    # @deprecated Use WidgetDataCacheTTL.TOP_VOLUME_SCANNER
     TOP_VOLUME_SCANNER = FOUR_DAYS
+
+    # @deprecated Use WidgetDataCacheTTL.TOP_GAINERS_SCANNER
     TOP_GAINERS_SCANNER = FOUR_DAYS
+
+    # @deprecated Use WidgetDataCacheTTL.TOP_GAPPERS_SCANNER
     TOP_GAPPERS_SCANNER = FOUR_DAYS
 
-    # Finlight news caches
+    # @deprecated Use WidgetDataCacheTTL.NEWS_FEED_LATEST
     NEWS_FEED_LATEST = TWO_DAYS
+
+    # @deprecated Use WidgetDataCacheTTL.NEWS_TICKER
     NEWS_TICKER = SEVEN_DAYS
+
+
+def _warn_deprecated_member(name: str) -> None:
+    warnings.warn(
+        f"MarketDataCacheTTL.{name} is deprecated as of v0.4.0 and will be removed in the "
+        f"next minor release. Use WidgetDataCacheTTL.{name} instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+_DEPRECATED_TTL_MEMBERS = frozenset({
+    "TOP_TRADES_WIDGET_CACHE_TTL",
+    "TOP_TRADES_ALL_SYMBOLS_CACHE_TTL",
+    "QUOTE",
+    "TOP_STOCKS_SCANNER",
+    "TOP_VOLUME_SCANNER",
+    "TOP_GAINERS_SCANNER",
+    "TOP_GAPPERS_SCANNER",
+    "NEWS_FEED_LATEST",
+    "NEWS_TICKER",
+})
+
+
+def __getattr__(name: str):
+    """Module-level __getattr__ to warn on access of deprecated enum members via module."""
+    if name in _DEPRECATED_TTL_MEMBERS:
+        _warn_deprecated_member(name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/kuhl_haus/mdp/enum/market_data_cache_ttl.py
+++ b/src/kuhl_haus/mdp/enum/market_data_cache_ttl.py
@@ -7,8 +7,11 @@ longer for reference data.
 
 For WDC-facing TTLs (scanner results, quote feed, news feeds), use
 :class:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL` instead.
-The following entries are deprecated as of v0.4.0 and will be removed in the
+
+The following members are deprecated as of v0.4.0 and will be removed in the
 next minor release:
+
+WDC entries (moved to WidgetDataCacheTTL):
 
 - ``QUOTE`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.QUOTE`
 - ``TOP_TRADES_WIDGET_CACHE_TTL`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_TRADES_WIDGET_CACHE_TTL`
@@ -19,6 +22,13 @@ next minor release:
 - ``TOP_GAPPERS_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_GAPPERS_SCANNER`
 - ``NEWS_FEED_LATEST`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.NEWS_FEED_LATEST`
 - ``NEWS_TICKER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.NEWS_TICKER`
+
+No active usages found (dead code):
+
+- ``NEGATIVE_CACHE_THROTTLE``
+- ``LEADERBOARD_TOP_VOLUME``
+- ``LEADERBOARD_TOP_GAPPERS``
+- ``LEADERBOARD_TOP_GAINERS``
 """
 import warnings
 from enum import Enum
@@ -48,9 +58,9 @@ class MarketDataCacheTTL(Enum):
 
     .. deprecated::
         The following members are deprecated as of v0.4.0 and will be removed in
-        the next minor release. Use the corresponding
-        :class:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL`
-        members instead:
+        the next minor release.
+
+        WDC entries — use :class:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL` instead:
 
         - ``QUOTE``
         - ``TOP_TRADES_WIDGET_CACHE_TTL``
@@ -61,9 +71,17 @@ class MarketDataCacheTTL(Enum):
         - ``TOP_GAPPERS_SCANNER``
         - ``NEWS_FEED_LATEST``
         - ``NEWS_TICKER``
+
+        No active usages found (dead code):
+
+        - ``NEGATIVE_CACHE_THROTTLE``
+        - ``LEADERBOARD_TOP_VOLUME``
+        - ``LEADERBOARD_TOP_GAPPERS``
+        - ``LEADERBOARD_TOP_GAINERS``
     """
-    # Negative Cache TTLs
+    # @deprecated — no active usages
     NEGATIVE_CACHE_THROTTLE = ONE_MINUTE
+
     NEGATIVE_CACHE_SESSION = SIX_HOURS
 
     # Raw market data caches
@@ -83,8 +101,12 @@ class MarketDataCacheTTL(Enum):
 
     # Leaderboard caches
     LEADERBOARD_ANALYZER = ONE_HOUR
+
+    # @deprecated — no active usages
     LEADERBOARD_TOP_VOLUME = THREE_DAYS
+    # @deprecated — no active usages
     LEADERBOARD_TOP_GAPPERS = THREE_DAYS
+    # @deprecated — no active usages
     LEADERBOARD_TOP_GAINERS = THREE_DAYS
 
     # Top Trades caches
@@ -130,6 +152,10 @@ def _warn_deprecated_member(name: str) -> None:
 
 
 _DEPRECATED_TTL_MEMBERS = frozenset({
+    "NEGATIVE_CACHE_THROTTLE",
+    "LEADERBOARD_TOP_VOLUME",
+    "LEADERBOARD_TOP_GAPPERS",
+    "LEADERBOARD_TOP_GAINERS",
     "TOP_TRADES_WIDGET_CACHE_TTL",
     "TOP_TRADES_ALL_SYMBOLS_CACHE_TTL",
     "QUOTE",

--- a/src/kuhl_haus/mdp/enum/market_data_cache_ttl.py
+++ b/src/kuhl_haus/mdp/enum/market_data_cache_ttl.py
@@ -9,26 +9,16 @@ For WDC-facing TTLs (scanner results, quote feed, news feeds), use
 :class:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL` instead.
 
 The following members are deprecated as of v0.4.0 and will be removed in the
-next minor release:
-
-WDC entries (moved to WidgetDataCacheTTL):
-
-- ``QUOTE`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.QUOTE`
-- ``TOP_TRADES_WIDGET_CACHE_TTL`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_TRADES_WIDGET_CACHE_TTL`
-- ``TOP_TRADES_ALL_SYMBOLS_CACHE_TTL`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_TRADES_ALL_SYMBOLS_CACHE_TTL`
-- ``TOP_STOCKS_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_STOCKS_SCANNER`
-- ``TOP_VOLUME_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_VOLUME_SCANNER`
-- ``TOP_GAINERS_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_GAINERS_SCANNER`
-- ``TOP_GAPPERS_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_GAPPERS_SCANNER`
-- ``NEWS_FEED_LATEST`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.NEWS_FEED_LATEST`
-- ``NEWS_TICKER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.NEWS_TICKER`
-
-No active usages found (dead code):
+next minor release (no active usages found in src/, tests/, or mdp-servers):
 
 - ``NEGATIVE_CACHE_THROTTLE``
 - ``LEADERBOARD_TOP_VOLUME``
 - ``LEADERBOARD_TOP_GAPPERS``
 - ``LEADERBOARD_TOP_GAINERS``
+- ``TOP_STOCKS_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_STOCKS_SCANNER`
+- ``TOP_VOLUME_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_VOLUME_SCANNER`
+- ``TOP_GAINERS_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_GAINERS_SCANNER`
+- ``TOP_GAPPERS_SCANNER`` → :attr:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL.TOP_GAPPERS_SCANNER`
 """
 import warnings
 from enum import Enum
@@ -58,26 +48,16 @@ class MarketDataCacheTTL(Enum):
 
     .. deprecated::
         The following members are deprecated as of v0.4.0 and will be removed in
-        the next minor release.
-
-        WDC entries — use :class:`~kuhl_haus.mdp.enum.widget_data_cache_ttl.WidgetDataCacheTTL` instead:
-
-        - ``QUOTE``
-        - ``TOP_TRADES_WIDGET_CACHE_TTL``
-        - ``TOP_TRADES_ALL_SYMBOLS_CACHE_TTL``
-        - ``TOP_STOCKS_SCANNER``
-        - ``TOP_VOLUME_SCANNER``
-        - ``TOP_GAINERS_SCANNER``
-        - ``TOP_GAPPERS_SCANNER``
-        - ``NEWS_FEED_LATEST``
-        - ``NEWS_TICKER``
-
-        No active usages found (dead code):
+        the next minor release (no active usages found):
 
         - ``NEGATIVE_CACHE_THROTTLE``
         - ``LEADERBOARD_TOP_VOLUME``
         - ``LEADERBOARD_TOP_GAPPERS``
         - ``LEADERBOARD_TOP_GAINERS``
+        - ``TOP_STOCKS_SCANNER`` → use ``WidgetDataCacheTTL.TOP_STOCKS_SCANNER``
+        - ``TOP_VOLUME_SCANNER`` → use ``WidgetDataCacheTTL.TOP_VOLUME_SCANNER``
+        - ``TOP_GAINERS_SCANNER`` → use ``WidgetDataCacheTTL.TOP_GAINERS_SCANNER``
+        - ``TOP_GAPPERS_SCANNER`` → use ``WidgetDataCacheTTL.TOP_GAPPERS_SCANNER``
     """
     # @deprecated — no active usages
     NEGATIVE_CACHE_THROTTLE = ONE_MINUTE
@@ -111,34 +91,26 @@ class MarketDataCacheTTL(Enum):
 
     # Top Trades caches
     TOP_TRADES_TRADE_TTL = FIVE_MINUTES
-
-    # --- Deprecated WDC entries (use WidgetDataCacheTTL) ---
-
-    # @deprecated Use WidgetDataCacheTTL.TOP_TRADES_WIDGET_CACHE_TTL
     TOP_TRADES_WIDGET_CACHE_TTL = ONE_MINUTE
-
-    # @deprecated Use WidgetDataCacheTTL.TOP_TRADES_ALL_SYMBOLS_CACHE_TTL
     TOP_TRADES_ALL_SYMBOLS_CACHE_TTL = ONE_MINUTE
 
-    # @deprecated Use WidgetDataCacheTTL.QUOTE
-    QUOTE = FOUR_DAYS
+    # Quote feed cache
+    QUOTE = FOUR_DAYS  # Stale data > no data; timestamp in payload shows freshness
 
-    # @deprecated Use WidgetDataCacheTTL.TOP_STOCKS_SCANNER
+    # @deprecated — no active usages; use WidgetDataCacheTTL.TOP_STOCKS_SCANNER
     TOP_STOCKS_SCANNER = EIGHT_HOURS
 
-    # @deprecated Use WidgetDataCacheTTL.TOP_VOLUME_SCANNER
+    # @deprecated — no active usages; use WidgetDataCacheTTL.TOP_VOLUME_SCANNER
     TOP_VOLUME_SCANNER = FOUR_DAYS
 
-    # @deprecated Use WidgetDataCacheTTL.TOP_GAINERS_SCANNER
+    # @deprecated — no active usages; use WidgetDataCacheTTL.TOP_GAINERS_SCANNER
     TOP_GAINERS_SCANNER = FOUR_DAYS
 
-    # @deprecated Use WidgetDataCacheTTL.TOP_GAPPERS_SCANNER
+    # @deprecated — no active usages; use WidgetDataCacheTTL.TOP_GAPPERS_SCANNER
     TOP_GAPPERS_SCANNER = FOUR_DAYS
 
-    # @deprecated Use WidgetDataCacheTTL.NEWS_FEED_LATEST
+    # Finlight news caches
     NEWS_FEED_LATEST = TWO_DAYS
-
-    # @deprecated Use WidgetDataCacheTTL.NEWS_TICKER
     NEWS_TICKER = SEVEN_DAYS
 
 
@@ -156,15 +128,10 @@ _DEPRECATED_TTL_MEMBERS = frozenset({
     "LEADERBOARD_TOP_VOLUME",
     "LEADERBOARD_TOP_GAPPERS",
     "LEADERBOARD_TOP_GAINERS",
-    "TOP_TRADES_WIDGET_CACHE_TTL",
-    "TOP_TRADES_ALL_SYMBOLS_CACHE_TTL",
-    "QUOTE",
     "TOP_STOCKS_SCANNER",
     "TOP_VOLUME_SCANNER",
     "TOP_GAINERS_SCANNER",
     "TOP_GAPPERS_SCANNER",
-    "NEWS_FEED_LATEST",
-    "NEWS_TICKER",
 })
 
 

--- a/src/kuhl_haus/mdp/enum/market_data_pubsub_keys.py
+++ b/src/kuhl_haus/mdp/enum/market_data_pubsub_keys.py
@@ -1,16 +1,34 @@
 """Redis pub/sub channel names for external Widget Data Service consumption.
 
+.. deprecated::
+    ``MarketDataPubSubKeys`` is deprecated as of v0.4.0 and will be removed in the next
+    minor release. Use :class:`~kuhl_haus.mdp.enum.widget_data_cache_keys.WidgetDataCacheKeys`
+    instead, which consolidates all WDC-facing pub/sub and cache keys.
+
 Channel keys published by the market data processor for downstream consumers.
 Widget Data Service subscribes to these channels to receive scanner results
 and push them to frontend clients via WebSocket.
 """
+import warnings
 from enum import Enum
 
 from kuhl_haus.mdp.enum.market_data_scanner_names import MarketDataScannerNames
 
+warnings.warn(
+    "MarketDataPubSubKeys is deprecated as of v0.4.0 and will be removed in the next minor release. "
+    "Use WidgetDataCacheKeys instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 class MarketDataPubSubKeys(Enum):
     """Redis channel identifiers for scanner result distribution.
+
+    .. deprecated::
+        ``MarketDataPubSubKeys`` is deprecated as of v0.4.0 and will be removed in the
+        next minor release. Use
+        :class:`~kuhl_haus.mdp.enum.widget_data_cache_keys.WidgetDataCacheKeys` instead.
 
     Published by MDP analyzers after processing real-time market data. Widget
     Data Service subscribes to forward results to frontend clients. Multiple

--- a/src/kuhl_haus/mdp/enum/market_data_pubsub_keys.py
+++ b/src/kuhl_haus/mdp/enum/market_data_pubsub_keys.py
@@ -5,6 +5,9 @@
     minor release. Use :class:`~kuhl_haus.mdp.enum.widget_data_cache_keys.WidgetDataCacheKeys`
     instead, which consolidates all WDC-facing pub/sub and cache keys.
 
+    Exception: ``NEWS_FEED_LATEST`` and ``NEWS_TICKER`` are still referenced in
+    tests and will be migrated in the same release.
+
 Channel keys published by the market data processor for downstream consumers.
 Widget Data Service subscribes to these channels to receive scanner results
 and push them to frontend clients via WebSocket.
@@ -30,6 +33,9 @@ class MarketDataPubSubKeys(Enum):
         next minor release. Use
         :class:`~kuhl_haus.mdp.enum.widget_data_cache_keys.WidgetDataCacheKeys` instead.
 
+        Exception: ``NEWS_FEED_LATEST`` and ``NEWS_TICKER`` are still referenced in
+        tests and will be migrated in the same release.
+
     Published by MDP analyzers after processing real-time market data. Widget
     Data Service subscribes to forward results to frontend clients. Multiple
     time windows available for Top Trades to support different UI refresh rates.
@@ -48,6 +54,6 @@ class MarketDataPubSubKeys(Enum):
     TOP_GAPPERS_SCANNER = f'scanners:{MarketDataScannerNames.TOP_GAPPERS.value}'
     TOP_VOLUME_SCANNER = f'scanners:{MarketDataScannerNames.TOP_VOLUME.value}'
 
-    # Finlight news feeds
+    # Finlight news feeds — still referenced in tests, migrating in next release
     NEWS_FEED_LATEST = 'news:feed:latest'
     NEWS_TICKER = 'news:ticker:{ticker}'

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_keys.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_keys.py
@@ -3,6 +3,15 @@
 All keys written by Analyzers/Processors and read by the Widget Data Service
 for real-time widget delivery. Replaces MarketDataPubSubKeys and consolidates
 WDC-facing keys from MarketDataCacheKeys.
+
+The following members are deprecated as of v0.4.0 and will be removed in the
+next minor release (no active usages found):
+
+- ``TOP_10_LISTS_SCANNER``
+- ``TOP_TRADES_SCANNER_ONE_HOUR``
+- ``TOP_TRADES_SCANNER_FIVE_MINUTES``
+- ``TOP_TRADES_SCANNER_ONE_MINUTE``
+- ``TOP_TRADES_SCANNER``
 """
 from enum import Enum
 
@@ -15,14 +24,27 @@ class WidgetDataCacheKeys(Enum):
     Published by MDP analyzers after processing real-time market data. Widget
     Data Service subscribes to forward results to frontend clients. Multiple
     time windows available for Top Trades to support different UI refresh rates.
+
+    .. deprecated::
+        The following members are deprecated as of v0.4.0 and will be removed in
+        the next minor release (no active usages found):
+
+        - ``TOP_10_LISTS_SCANNER``
+        - ``TOP_TRADES_SCANNER_ONE_HOUR``
+        - ``TOP_TRADES_SCANNER_FIVE_MINUTES``
+        - ``TOP_TRADES_SCANNER_ONE_MINUTE``
+        - ``TOP_TRADES_SCANNER``
     """
-    # Top Trades Scanner channels
+    # @deprecated — no active usages
     TOP_10_LISTS_SCANNER = 'scanners:top_10_lists'
+    # @deprecated — no active usages
     TOP_TRADES_SCANNER_ONE_HOUR = f'scanners:{MarketDataScannerNames.TOP_TRADES.value}:1h'
+    # @deprecated — no active usages
     TOP_TRADES_SCANNER_FIVE_MINUTES = f'scanners:{MarketDataScannerNames.TOP_TRADES.value}:5m'
+    # @deprecated — no active usages
     TOP_TRADES_SCANNER_ONE_MINUTE = f'scanners:{MarketDataScannerNames.TOP_TRADES.value}:1m'
 
-    # Top Trades widget cache keys (formerly MarketDataCacheKeys)
+    # Top Trades widget cache keys
     TOP_TRADES_WIDGET_CACHE_KEY = "tta:{symbol}:widget"
     TOP_TRADES_ALL_SYMBOLS_CACHE_KEY = "tta:all_symbols:widget"
 
@@ -34,7 +56,8 @@ class WidgetDataCacheKeys(Enum):
     TOP_GAPPERS_SCANNER = f'scanners:{MarketDataScannerNames.TOP_GAPPERS.value}'
     TOP_VOLUME_SCANNER = f'scanners:{MarketDataScannerNames.TOP_VOLUME.value}'
 
-    # Scanner result cache keys (formerly MarketDataCacheKeys)
+    # Scanner result cache keys
+    # @deprecated — no active usages
     TOP_TRADES_SCANNER = f'cache:{MarketDataScannerNames.TOP_TRADES.value}'
     TOP_STOCKS_SCANNER = f'cache:{MarketDataScannerNames.TOP_STOCKS.value}'
 

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
@@ -3,6 +3,12 @@
 Defines expiration times for all widget-facing cached data. These TTLs govern
 how long Processor/Analyzer results remain available in the WDC for widget
 consumption. Separated from MarketDataCacheTTL which governs internal MDC data.
+
+The following members are deprecated as of v0.4.0 and will be removed in the
+next minor release (no active usages found):
+
+- ``TOP_TRADES_WIDGET_CACHE_TTL``
+- ``TOP_TRADES_ALL_SYMBOLS_CACHE_TTL``
 """
 from enum import Enum
 
@@ -19,6 +25,13 @@ class WidgetDataCacheTTL(Enum):
 
     Covers scanner results, quote feeds, and news feeds — all data written
     by Analyzers and consumed by the Widget Data Service.
+
+    .. deprecated::
+        The following members are deprecated as of v0.4.0 and will be removed in
+        the next minor release (no active usages found):
+
+        - ``TOP_TRADES_WIDGET_CACHE_TTL``
+        - ``TOP_TRADES_ALL_SYMBOLS_CACHE_TTL``
     """
     # Quote feed
     QUOTE = FOUR_DAYS  # Stale data > no data; timestamp in payload shows freshness
@@ -29,8 +42,9 @@ class WidgetDataCacheTTL(Enum):
     TOP_GAINERS_SCANNER = FOUR_DAYS
     TOP_GAPPERS_SCANNER = FOUR_DAYS
 
-    # Top Trades widget caches
+    # @deprecated — no active usages
     TOP_TRADES_WIDGET_CACHE_TTL = ONE_MINUTE
+    # @deprecated — no active usages
     TOP_TRADES_ALL_SYMBOLS_CACHE_TTL = ONE_MINUTE
 
     # Finlight news caches

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
@@ -3,12 +3,6 @@
 Defines expiration times for all widget-facing cached data. These TTLs govern
 how long Processor/Analyzer results remain available in the WDC for widget
 consumption. Separated from MarketDataCacheTTL which governs internal MDC data.
-
-The following members are deprecated as of v0.4.0 and will be removed in the
-next minor release (no active usages found):
-
-- ``TOP_TRADES_WIDGET_CACHE_TTL``
-- ``TOP_TRADES_ALL_SYMBOLS_CACHE_TTL``
 """
 from enum import Enum
 
@@ -25,13 +19,6 @@ class WidgetDataCacheTTL(Enum):
 
     Covers scanner results, quote feeds, and news feeds — all data written
     by Analyzers and consumed by the Widget Data Service.
-
-    .. deprecated::
-        The following members are deprecated as of v0.4.0 and will be removed in
-        the next minor release (no active usages found):
-
-        - ``TOP_TRADES_WIDGET_CACHE_TTL``
-        - ``TOP_TRADES_ALL_SYMBOLS_CACHE_TTL``
     """
     # Quote feed
     QUOTE = FOUR_DAYS  # Stale data > no data; timestamp in payload shows freshness
@@ -42,9 +29,8 @@ class WidgetDataCacheTTL(Enum):
     TOP_GAINERS_SCANNER = FOUR_DAYS
     TOP_GAPPERS_SCANNER = FOUR_DAYS
 
-    # @deprecated — no active usages
+    # Top Trades widget caches
     TOP_TRADES_WIDGET_CACHE_TTL = ONE_MINUTE
-    # @deprecated — no active usages
     TOP_TRADES_ALL_SYMBOLS_CACHE_TTL = ONE_MINUTE
 
     # Finlight news caches

--- a/tests/analyzers/test_finlight_data_analyzer.py
+++ b/tests/analyzers/test_finlight_data_analyzer.py
@@ -9,8 +9,8 @@ from unittest.mock import MagicMock
 
 from kuhl_haus.mdp.analyzers.finlight_data_analyzer import FinlightDataAnalyzer
 from kuhl_haus.mdp.enum.finlight_data_cache import FinlightDataCache
-from kuhl_haus.mdp.enum.market_data_pubsub_keys import MarketDataPubSubKeys
-from kuhl_haus.mdp.enum.market_data_cache_ttl import MarketDataCacheTTL
+from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
 from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
 from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
 
@@ -114,7 +114,7 @@ async def test_fda_analyze_data_with_any_article_expect_feed_published(sut):
 
     # Assert
     assert results is not None
-    feed_results = [r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value]
+    feed_results = [r for r in results if r.publish_key == WidgetDataCacheKeys.NEWS_FEED_LATEST.value]
     assert len(feed_results) == 1
 
 
@@ -127,8 +127,8 @@ async def test_fda_analyze_data_with_feed_result_expect_correct_cache_key(sut):
     results = await sut.analyze_data(article)
 
     # Assert
-    feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
-    assert feed.cache_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value
+    feed = next(r for r in results if r.publish_key == WidgetDataCacheKeys.NEWS_FEED_LATEST.value)
+    assert feed.cache_key == WidgetDataCacheKeys.NEWS_FEED_LATEST.value
     assert feed.data is article
 
 
@@ -141,8 +141,8 @@ async def test_fda_analyze_data_with_feed_result_expect_zero_ttl(sut):
     results = await sut.analyze_data(article)
 
     # Assert
-    feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
-    assert feed.cache_ttl == MarketDataCacheTTL.NEWS_FEED_LATEST.value
+    feed = next(r for r in results if r.publish_key == WidgetDataCacheKeys.NEWS_FEED_LATEST.value)
+    assert feed.cache_ttl == WidgetDataCacheTTL.NEWS_FEED_LATEST.value
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +153,7 @@ async def test_fda_analyze_data_with_feed_result_expect_zero_ttl(sut):
 async def test_fda_analyze_data_with_enhanced_nasdaq_company_expect_ticker_published(sut):
     # Arrange
     article = _enhanced_article(companies=[_company("ATOS", "XNAS")])
-    publish_key = MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="ATOS")
+    publish_key = WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="ATOS")
 
     # Act
     results = await sut.analyze_data(article)
@@ -174,7 +174,7 @@ async def test_fda_analyze_data_with_enhanced_nyse_company_expect_ticker_publish
     results = await sut.analyze_data(article)
 
     # Assert
-    assert any(r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="GM") for r in results)
+    assert any(r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="GM") for r in results)
 
 
 @pytest.mark.asyncio
@@ -186,7 +186,7 @@ async def test_fda_analyze_data_with_enhanced_amex_company_expect_ticker_publish
     results = await sut.analyze_data(article)
 
     # Assert
-    assert any(r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="XYZ") for r in results)
+    assert any(r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="XYZ") for r in results)
 
 
 @pytest.mark.asyncio
@@ -214,8 +214,8 @@ async def test_fda_analyze_data_with_enhanced_mixed_exchanges_expect_only_us_tic
 
     # Assert
     ticker_keys = [r.publish_key for r in results if r.publish_key and r.publish_key.startswith("news:ticker:")]
-    assert MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="MSFT") in ticker_keys
-    assert MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="STLAP") not in ticker_keys
+    assert WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="MSFT") in ticker_keys
+    assert WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="STLAP") not in ticker_keys
 
 
 @pytest.mark.asyncio
@@ -231,8 +231,8 @@ async def test_fda_analyze_data_with_enhanced_multiple_us_companies_expect_all_p
 
     # Assert
     ticker_keys = {r.publish_key for r in results if r.publish_key and r.publish_key.startswith("news:ticker:")}
-    assert MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="JPM") in ticker_keys
-    assert MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="META") in ticker_keys
+    assert WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="JPM") in ticker_keys
+    assert WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="META") in ticker_keys
 
 
 @pytest.mark.asyncio
@@ -245,7 +245,7 @@ async def test_fda_analyze_data_with_enhanced_empty_companies_expect_feed_only(s
 
     # Assert — falls through to raw mode; no tickers in text either
     assert len(results) == 1
-    assert results[0].publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value
+    assert results[0].publish_key == WidgetDataCacheKeys.NEWS_FEED_LATEST.value
 
 
 @pytest.mark.asyncio
@@ -276,7 +276,7 @@ async def test_fda_analyze_data_with_raw_nasdaq_ticker_in_title_expect_published
     results = await sut.analyze_data(article)
 
     # Assert
-    assert any(r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="ATOS") for r in results)
+    assert any(r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="ATOS") for r in results)
 
 
 @pytest.mark.asyncio
@@ -291,7 +291,7 @@ async def test_fda_analyze_data_with_raw_nyse_ticker_in_summary_expect_published
     results = await sut.analyze_data(article)
 
     # Assert
-    assert any(r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="FUBO") for r in results)
+    assert any(r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="FUBO") for r in results)
 
 
 @pytest.mark.asyncio
@@ -303,7 +303,7 @@ async def test_fda_analyze_data_with_raw_ticker_no_space_expect_published(sut):
     results = await sut.analyze_data(article)
 
     # Assert
-    assert any(r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="GM") for r in results)
+    assert any(r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="GM") for r in results)
 
 
 @pytest.mark.asyncio
@@ -319,8 +319,8 @@ async def test_fda_analyze_data_with_raw_multiple_tickers_expect_all_published(s
 
     # Assert
     keys = {r.publish_key for r in results}
-    assert MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="MSFT") in keys
-    assert MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL") in keys
+    assert WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="MSFT") in keys
+    assert WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL") in keys
 
 
 @pytest.mark.asyncio
@@ -333,14 +333,14 @@ async def test_fda_analyze_data_with_raw_no_tickers_expect_feed_only(sut):
 
     # Assert
     assert len(results) == 1
-    assert results[0].publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value
+    assert results[0].publish_key == WidgetDataCacheKeys.NEWS_FEED_LATEST.value
 
 
 @pytest.mark.asyncio
 async def test_fda_analyze_data_with_raw_ticker_cache_key_is_none(sut):
     # Arrange
     article = _raw_article(title="Chewy (Nasdaq: CHWY) beats estimates")
-    publish_key = MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="CHWY")
+    publish_key = WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="CHWY")
 
     # Act
     results = await sut.analyze_data(article)
@@ -491,7 +491,7 @@ async def test_fda_analyze_data_with_feed_result_expect_cache_list_max(sut):
     results = await sut.analyze_data(article)
 
     # Assert
-    feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
+    feed = next(r for r in results if r.publish_key == WidgetDataCacheKeys.NEWS_FEED_LATEST.value)
     assert feed.cache_list_max == FinlightDataCache.NEWS_FEED_LIST_MAX.value
 
 
@@ -506,9 +506,9 @@ async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_key_set(sut):
     # Assert
     ticker_result = next(
         r for r in results
-        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+        if r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
-    assert ticker_result.cache_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+    assert ticker_result.cache_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL")
 
 
 @pytest.mark.asyncio
@@ -522,7 +522,7 @@ async def test_fda_analyze_data_with_enhanced_ticker_expect_cache_list_max(sut):
     # Assert
     ticker_result = next(
         r for r in results
-        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+        if r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
     assert ticker_result.cache_list_max == FinlightDataCache.NEWS_TICKER_LIST_MAX.value
 
@@ -538,9 +538,9 @@ async def test_fda_analyze_data_with_raw_ticker_expect_cache_key_set(sut):
     # Assert
     ticker_result = next(
         r for r in results
-        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+        if r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
-    assert ticker_result.cache_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+    assert ticker_result.cache_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL")
 
 
 @pytest.mark.asyncio
@@ -554,7 +554,7 @@ async def test_fda_analyze_data_with_raw_ticker_expect_cache_list_max(sut):
     # Assert
     ticker_result = next(
         r for r in results
-        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+        if r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
     assert ticker_result.cache_list_max == FinlightDataCache.NEWS_TICKER_LIST_MAX.value
 
@@ -597,7 +597,7 @@ async def test_fda_analyze_data_with_kwargs_override_expect_custom_feed_limit():
     results = await sut.analyze_data(article)
 
     # Assert — feed result uses overridden limit
-    feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
+    feed = next(r for r in results if r.publish_key == WidgetDataCacheKeys.NEWS_FEED_LATEST.value)
     assert feed.cache_list_max == 999
 
 
@@ -617,7 +617,7 @@ async def test_fda_analyze_data_with_kwargs_override_expect_custom_ticker_limit(
     # Assert — ticker result uses overridden limit
     ticker_result = next(
         r for r in results
-        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+        if r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
     assert ticker_result.cache_list_max == 42
 
@@ -634,8 +634,8 @@ async def test_fda_init_with_no_kwargs_expect_ttl_enum_defaults():
     sut = FinlightDataAnalyzer(opts)
 
     # Assert
-    assert sut.news_feed_cache_ttl == MarketDataCacheTTL.NEWS_FEED_LATEST.value
-    assert sut.news_ticker_cache_ttl == MarketDataCacheTTL.NEWS_TICKER.value
+    assert sut.news_feed_cache_ttl == WidgetDataCacheTTL.NEWS_FEED_LATEST.value
+    assert sut.news_ticker_cache_ttl == WidgetDataCacheTTL.NEWS_TICKER.value
 
 
 @pytest.mark.asyncio
@@ -655,7 +655,7 @@ async def test_fda_init_with_ttl_kwargs_expect_custom_ttls():
 
 @pytest.mark.asyncio
 async def test_fda_analyze_data_with_default_feed_ttl_expect_enum_value():
-    """Feed result cache_ttl uses MarketDataCacheTTL.NEWS_FEED_LATEST by default."""
+    """Feed result cache_ttl uses WidgetDataCacheTTL.NEWS_FEED_LATEST by default."""
     # Arrange
     opts = AnalyzerOptions(redis_url="redis://localhost")
     sut = FinlightDataAnalyzer(opts)
@@ -665,8 +665,8 @@ async def test_fda_analyze_data_with_default_feed_ttl_expect_enum_value():
     results = await sut.analyze_data(article)
 
     # Assert
-    feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
-    assert feed.cache_ttl == MarketDataCacheTTL.NEWS_FEED_LATEST.value
+    feed = next(r for r in results if r.publish_key == WidgetDataCacheKeys.NEWS_FEED_LATEST.value)
+    assert feed.cache_ttl == WidgetDataCacheTTL.NEWS_FEED_LATEST.value
 
 
 @pytest.mark.asyncio
@@ -685,13 +685,13 @@ async def test_fda_analyze_data_with_custom_feed_ttl_expect_override_used():
     results = await sut.analyze_data(article)
 
     # Assert
-    feed = next(r for r in results if r.publish_key == MarketDataPubSubKeys.NEWS_FEED_LATEST.value)
+    feed = next(r for r in results if r.publish_key == WidgetDataCacheKeys.NEWS_FEED_LATEST.value)
     assert feed.cache_ttl == custom_ttl
 
 
 @pytest.mark.asyncio
 async def test_fda_analyze_data_with_default_ticker_ttl_expect_enum_value():
-    """Ticker result cache_ttl uses MarketDataCacheTTL.NEWS_TICKER by default."""
+    """Ticker result cache_ttl uses WidgetDataCacheTTL.NEWS_TICKER by default."""
     # Arrange
     opts = AnalyzerOptions(redis_url="redis://localhost")
     sut = FinlightDataAnalyzer(opts)
@@ -703,9 +703,9 @@ async def test_fda_analyze_data_with_default_ticker_ttl_expect_enum_value():
     # Assert
     ticker = next(
         r for r in results
-        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+        if r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
-    assert ticker.cache_ttl == MarketDataCacheTTL.NEWS_TICKER.value
+    assert ticker.cache_ttl == WidgetDataCacheTTL.NEWS_TICKER.value
 
 
 @pytest.mark.asyncio
@@ -726,7 +726,7 @@ async def test_fda_analyze_data_with_custom_ticker_ttl_expect_override_used():
     # Assert
     ticker = next(
         r for r in results
-        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+        if r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
     assert ticker.cache_ttl == custom_ttl
 
@@ -749,6 +749,6 @@ async def test_fda_analyze_data_with_custom_ticker_ttl_expect_raw_ticker_overrid
     # Assert
     ticker = next(
         r for r in results
-        if r.publish_key == MarketDataPubSubKeys.NEWS_TICKER.value.format(ticker="AAPL")
+        if r.publish_key == WidgetDataCacheKeys.NEWS_TICKER.value.format(ticker="AAPL")
     )
     assert ticker.cache_ttl == custom_ttl

--- a/tests/test_widget_data_cache_enums.py
+++ b/tests/test_widget_data_cache_enums.py
@@ -65,8 +65,8 @@ def test_widget_data_cache_ttl_module_exists():
 
 def test_widget_data_cache_ttl_has_quote():
     from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
-    from kuhl_haus.mdp.enum.market_data_cache_ttl import MarketDataCacheTTL
-    assert WidgetDataCacheTTL.QUOTE.value == MarketDataCacheTTL.QUOTE.value
+    from kuhl_haus.mdp.enum.constants import FOUR_DAYS
+    assert WidgetDataCacheTTL.QUOTE.value == FOUR_DAYS
 
 
 def test_widget_data_cache_ttl_has_scanner_ttls():


### PR DESCRIPTION
Updates `architecture.rst` to reflect the v0.4.0 MDC/WDC split and the MDS as a first-class component.

**Changes:**
- Add **Market Data Scanner (MDS)** to Components Summary and Component Descriptions (based on Tom's updated docstrings — commit 1178397)
  - Redis-only, post-processed data, secondary analysis (event correlation, alert generation, trend analysis, pattern recognition)
  - Code libraries: `MarketDataScanner`, `FinlightDataAnalyzer`, `AnalyzerOptions`, `WidgetDataCacheKeys`, `WidgetDataCacheTTL`
- Add **Widget Data Cache (WDC)** to Components Summary and Component Descriptions
  - Separate Redis instance from MDC; client-facing; `WidgetDataCacheKeys` + `WidgetDataCacheTTL` as primary enums
- Update **MDC** description: explicitly "internal" store, separate Redis instance
- **`MarketDataPubSubKeys`**: note kept for backward compat; prefer `WidgetDataCacheKeys` for new work
- Remove `MarketDataScanner` from MDP code libraries (moved to MDS section where it belongs)
- Add `WidgetDataCacheKeys` to WDS code libraries
- Update Deployment Model to include MDS and WDC in data plane list

refs #75