### PR TITLE
fix: strip credentials from https remote URLs in update-changelog.sh

### DIFF
--- a/update-changelog.sh
+++ b/update-changelog.sh
@@ -31,7 +31,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-repo_url=$(git remote get-url origin | sed 's/\.git$//' | sed 's|git@github\.com:|https://github.com/|')
+repo_url=$(git remote get-url origin | sed 's/\.git$//' | sed 's|git@github\.com:|https://github.com/|' | sed 's|https://[^@]*@github\.com/|https://github.com/|')
 
 outfile="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/CHANGELOG.rst"
 


### PR DESCRIPTION
Adds a `sed` to strip `user:token@` from `https://` remote URLs before embedding them in changelog commit links. Prevents PAT leakage when the remote is configured with embedded credentials.