### PR TITLE
ci: enforce 98% minimum coverage in publish-to-pypi workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -40,7 +40,7 @@ jobs:
 
     # Tests
     - name: Run tests with coverage
-      run: pdm run pytest --cov=kuhl_haus.mdp --cov-report=html --cov-report=xml tests -v
+      run: pdm run pytest --cov=kuhl_haus.mdp --cov-report=html --cov-report=xml --cov-fail-under=98 tests -v
     - name: Upload coverage report
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Adds `--cov-fail-under=98` to the test step. The PyPI publish workflow will now fail if branch coverage drops below 98% on a release tag.