### PR TITLE
feat: EnhancedQuoteAnalyzer — session HOD/LOD tracking + enrichment via MDS

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
@@ -1,0 +1,425 @@
+"""Enhanced quote analyzer with session HOD/LOD tracking and MDS enrichment.
+
+Processes incoming quote events and publishes enriched payloads to the WDC,
+combining real-time session high/low tracking with reference data (overview,
+short interest, short volume, splits) fetched via a three-tier cache
+(memory → Redis → REST API).
+
+Session windows (Eastern Time):
+- Pre-market:     04:00–09:30
+- Regular:        09:30–16:00
+- After-hours:    16:00–20:00
+"""
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Optional, List
+from zoneinfo import ZoneInfo
+
+from kuhl_haus.mdp.analyzers.analyzer import Analyzer, AnalyzerOptions
+from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
+from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
+from kuhl_haus.mdp.helpers.observability import get_tracer
+
+tracer = get_tracer(__name__)
+
+# Enrichment Redis TTLs (seconds)
+_OVERVIEW_TTL = 30 * 86400       # 30 days — effectively static reference data
+_SHORT_INTEREST_TTL = 14 * 86400  # 14 days — bi-monthly publication cadence
+_SHORT_VOLUME_TTL = 86400         # 24 hours — daily short volume data
+_SPLITS_TTL = 86400               # 24 hours — splits are infrequent but daily cache is safe
+
+
+class EnhancedQuoteAnalyzer(Analyzer):
+    """Enriches real-time quote events with session HOD/LOD and reference data.
+
+    Maintains per-symbol high/low for three intraday sessions (pre-market,
+    regular, after-hours) in process memory. Enrichment data (company
+    overview, short interest, short volume, splits) is resolved through a
+    three-tier cache: process memory → Redis WDC → REST API.
+
+    Boundary resets:
+    - 4:00 AM ET: all six HOD/LOD dicts cleared (atomic Lua script on Redis)
+    - 9:30 AM ET: pre-market HOD/LOD cleared (SET NX per-day guard)
+
+    Concurrency: HOD/LOD state is per-instance (not coordinated across
+    replicas). Each instance maintains its own window; the enrichment
+    Redis cache is shared and prevents redundant API calls cluster-wide.
+    """
+
+    DAY_BOUNDARY_KEY = "enhanced_quote:day_boundary"
+    MARKET_OPEN_RESET_KEY = "enhanced_quote:market_open_reset:{date}"
+
+    def __init__(self, options: AnalyzerOptions):
+        super().__init__(options)
+        self.logger = logging.getLogger(__name__)
+        self.redis_client = options.new_redis_client()
+        self.rest_client = options.new_rest_client()
+
+        # Session HOD/LOD — in-memory, per-instance
+        self._pre_market_high: dict = {}
+        self._pre_market_low: dict = {}
+        self._regular_session_high: dict = {}
+        self._regular_session_low: dict = {}
+        self._after_hours_high: dict = {}
+        self._after_hours_low: dict = {}
+
+        # Three-tier enrichment memory caches
+        self._overview_cache: dict = {}
+        self._short_interest_cache: dict = {}
+        self._short_volume_cache: dict = {}
+        self._splits_cache: dict = {}
+
+    @tracer.start_as_current_span("eqa.analyze_data")
+    async def analyze_data(self, data: dict) -> Optional[List[MarketDataAnalyzerResult]]:
+        """Process a quote event and return an enriched enhanced_quote result.
+
+        Steps:
+        1. Validate symbol presence.
+        2. Check day/market boundaries (clear HOD/LOD as needed).
+        3. Update session HOD/LOD from this event.
+        4. Fetch enrichment via three-tier cache.
+        5. Build and return the enhanced payload.
+
+        Args:
+            data: Quote event dict with at minimum a ``symbol`` key.
+
+        Returns:
+            Single-element list with a MarketDataAnalyzerResult, or None if
+            the event lacks a symbol.
+        """
+        symbol = data.get("symbol")
+        if not symbol:
+            return None
+
+        await self._check_day_boundary()
+        await self._check_market_open_reset()
+
+        self._update_session_hod_lod(symbol, data)
+
+        overview_data = await self._get_overview(symbol)
+        short_interest_data = await self._get_short_interest(symbol)
+        short_volume_data = await self._get_short_volume(symbol)
+        splits_data = await self._get_splits(symbol)
+
+        payload = {
+            **data,
+            "pre_market_high": self._pre_market_high.get(symbol),
+            "pre_market_low": self._pre_market_low.get(symbol),
+            "regular_session_high": self._regular_session_high.get(symbol),
+            "regular_session_low": self._regular_session_low.get(symbol),
+            "after_hours_high": self._after_hours_high.get(symbol),
+            "after_hours_low": self._after_hours_low.get(symbol),
+            "short_interest": short_interest_data.get("short_interest"),
+            "days_to_cover": short_interest_data.get("days_to_cover"),
+            "short_volume_ratio": short_volume_data.get("short_volume_ratio"),
+            "splits": splits_data or [],
+            "name": overview_data.get("name"),
+            "description": overview_data.get("description"),
+            "homepage_url": overview_data.get("homepage_url"),
+            "list_date": overview_data.get("list_date"),
+            "market_cap": overview_data.get("market_cap"),
+            "primary_exchange": overview_data.get("primary_exchange"),
+            "sic_description": overview_data.get("sic_description"),
+            "total_employees": overview_data.get("total_employees"),
+            "share_class_shares_outstanding": overview_data.get("share_class_shares_outstanding"),
+        }
+
+        cache_key = f"{WidgetDataCacheKeys.ENHANCED_QUOTE.value}:{symbol}"
+        return [MarketDataAnalyzerResult(
+            data=payload,
+            cache_key=cache_key,
+            cache_ttl=WidgetDataCacheTTL.ENHANCED_QUOTE.value,
+            publish_key=cache_key,
+        )]
+
+    def _get_session(self, start_timestamp: int) -> Optional[str]:
+        """Detect intraday session from a millisecond UTC timestamp.
+
+        Converts the timestamp to Eastern Time and maps it to a session window.
+
+        Args:
+            start_timestamp: Event start time in milliseconds since epoch (UTC).
+
+        Returns:
+            ``'pre_market'``, ``'regular'``, ``'after_hours'``, or ``None``
+            if outside all session windows.
+        """
+        dt = datetime.fromtimestamp(
+            start_timestamp / 1000, tz=timezone.utc
+        ).astimezone(ZoneInfo("America/New_York"))
+        total_minutes = dt.hour * 60 + dt.minute
+
+        if 4 * 60 <= total_minutes < 9 * 60 + 30:
+            return "pre_market"
+        elif 9 * 60 + 30 <= total_minutes < 16 * 60:
+            return "regular"
+        elif 16 * 60 <= total_minutes < 20 * 60:
+            return "after_hours"
+        return None
+
+    def _update_session_hod_lod(self, symbol: str, data: dict):
+        """Update in-memory session high/low from the event's high/low fields.
+
+        Skips update if ``start_timestamp`` is absent or the event falls
+        outside all session windows.
+
+        Args:
+            symbol: Ticker symbol.
+            data:   Quote event dict containing ``start_timestamp``, ``high``,
+                    and ``low`` fields.
+        """
+        start_timestamp = data.get("start_timestamp")
+        if not start_timestamp:
+            return
+
+        session = self._get_session(start_timestamp)
+        if session is None:
+            return
+
+        if session == "pre_market":
+            high_dict = self._pre_market_high
+            low_dict = self._pre_market_low
+        elif session == "regular":
+            high_dict = self._regular_session_high
+            low_dict = self._regular_session_low
+        else:  # after_hours
+            high_dict = self._after_hours_high
+            low_dict = self._after_hours_low
+
+        new_high = data.get("high")
+        if new_high is not None:
+            current = high_dict.get(symbol)
+            if current is None or new_high > current:
+                high_dict[symbol] = new_high
+
+        new_low = data.get("low")
+        if new_low is not None:
+            current = low_dict.get(symbol)
+            if current is None or new_low < current:
+                low_dict[symbol] = new_low
+
+    @tracer.start_as_current_span("eqa._check_day_boundary")
+    async def _check_day_boundary(self):
+        """Reset all six HOD/LOD dicts at 4:00 AM ET (new trading day).
+
+        Uses a Lua script for atomic check-and-set on the Redis day boundary
+        key. Only one instance across the cluster updates the key; all
+        instances clear their own in-memory state when the Lua script signals
+        a new day (returns 1).
+        """
+        et_now = datetime.now(timezone.utc).astimezone(ZoneInfo("America/New_York"))
+        current_day = et_now.replace(hour=4, minute=0, second=0, microsecond=0)
+        current_day_ts = str(int(current_day.timestamp()))
+
+        lua_script = """
+        local stored = redis.call('GET', KEYS[1])
+        if stored ~= ARGV[1] then
+            redis.call('SET', KEYS[1], ARGV[1])
+            return 1
+        end
+        return 0
+        """
+
+        reset = await self.redis_client.eval(
+            lua_script,
+            1,
+            self.DAY_BOUNDARY_KEY,
+            current_day_ts,
+        )
+
+        if reset:
+            self._pre_market_high.clear()
+            self._pre_market_low.clear()
+            self._regular_session_high.clear()
+            self._regular_session_low.clear()
+            self._after_hours_high.clear()
+            self._after_hours_low.clear()
+            self.logger.info(f"Day boundary reset at {current_day}")
+
+    @tracer.start_as_current_span("eqa._check_market_open_reset")
+    async def _check_market_open_reset(self):
+        """Clear pre-market HOD/LOD at 9:30 AM ET (regular session opens).
+
+        Only triggers during the 9:30–9:31 AM ET window. Uses SET NX with a
+        1-hour TTL to ensure single execution per day across all instances.
+        Pre-market H/L are superseded by regular-session tracking once the
+        market opens.
+        """
+        et_now = datetime.now(timezone.utc).astimezone(ZoneInfo("America/New_York"))
+
+        if not (et_now.hour == 9 and 30 <= et_now.minute < 31):
+            return
+
+        today = et_now.strftime("%Y-%m-%d")
+        reset_key = self.MARKET_OPEN_RESET_KEY.format(date=today)
+
+        was_set = await self.redis_client.set(reset_key, "1", ex=3600, nx=True)
+
+        if was_set:
+            self._pre_market_high.clear()
+            self._pre_market_low.clear()
+            self.logger.info(f"Market open reset for {today}")
+
+    @tracer.start_as_current_span("eqa._get_overview")
+    async def _get_overview(self, symbol: str) -> dict:
+        """Fetch ticker overview via three-tier cache (memory → Redis → API).
+
+        Extracts name, description, exchange, market cap, and other reference
+        fields from the Polygon ``/v3/reference/tickers/{symbol}`` endpoint.
+
+        Args:
+            symbol: Ticker symbol.
+
+        Returns:
+            Dict with overview fields, or empty dict on error/no data.
+        """
+        if symbol in self._overview_cache:
+            return self._overview_cache[symbol]
+
+        redis_key = f"enrichment:overview:{symbol}"
+        cached = await self.redis_client.get(redis_key)
+        if cached:
+            data = json.loads(cached)
+            self._overview_cache[symbol] = data
+            return data
+
+        data = {}
+        try:
+            response = self.rest_client.get_ticker_details(symbol)
+            if response and getattr(response, "results", None):
+                r = response.results
+                data = {
+                    "name": getattr(r, "name", None),
+                    "description": getattr(r, "description", None),
+                    "homepage_url": getattr(r, "homepage_url", None),
+                    "list_date": getattr(r, "list_date", None),
+                    "market_cap": getattr(r, "market_cap", None),
+                    "primary_exchange": getattr(r, "primary_exchange", None),
+                    "sic_description": getattr(r, "sic_description", None),
+                    "total_employees": getattr(r, "total_employees", None),
+                    "share_class_shares_outstanding": getattr(
+                        r, "share_class_shares_outstanding", None
+                    ),
+                }
+        except Exception as e:
+            self.logger.error(f"Error fetching overview for {symbol}: {e}")
+
+        self._overview_cache[symbol] = data
+        await self.redis_client.setex(redis_key, _OVERVIEW_TTL, json.dumps(data))
+        return data
+
+    @tracer.start_as_current_span("eqa._get_short_interest")
+    async def _get_short_interest(self, symbol: str) -> dict:
+        """Fetch short interest via three-tier cache (memory → Redis → API).
+
+        Calls Polygon ``/v3/reference/stocks/short_interest?ticker={symbol}&limit=1``.
+
+        Args:
+            symbol: Ticker symbol.
+
+        Returns:
+            Dict with ``short_interest`` and ``days_to_cover``, or empty dict.
+        """
+        if symbol in self._short_interest_cache:
+            return self._short_interest_cache[symbol]
+
+        redis_key = f"enrichment:short_interest:{symbol}"
+        cached = await self.redis_client.get(redis_key)
+        if cached:
+            data = json.loads(cached)
+            self._short_interest_cache[symbol] = data
+            return data
+
+        data = {}
+        try:
+            items = list(self.rest_client.list_short_interest(ticker=symbol, limit=1))
+            if items:
+                item = items[0]
+                data = {
+                    "short_interest": getattr(item, "short_interest", None),
+                    "days_to_cover": getattr(item, "days_to_cover", None),
+                }
+        except Exception as e:
+            self.logger.error(f"Error fetching short interest for {symbol}: {e}")
+
+        self._short_interest_cache[symbol] = data
+        await self.redis_client.setex(redis_key, _SHORT_INTEREST_TTL, json.dumps(data))
+        return data
+
+    @tracer.start_as_current_span("eqa._get_short_volume")
+    async def _get_short_volume(self, symbol: str) -> dict:
+        """Fetch short volume ratio via three-tier cache (memory → Redis → API).
+
+        Calls Polygon ``/v3/reference/stocks/short_volume?ticker={symbol}&limit=1&order=desc``.
+
+        Args:
+            symbol: Ticker symbol.
+
+        Returns:
+            Dict with ``short_volume_ratio``, or empty dict.
+        """
+        if symbol in self._short_volume_cache:
+            return self._short_volume_cache[symbol]
+
+        redis_key = f"enrichment:short_volume:{symbol}"
+        cached = await self.redis_client.get(redis_key)
+        if cached:
+            data = json.loads(cached)
+            self._short_volume_cache[symbol] = data
+            return data
+
+        data = {}
+        try:
+            items = list(self.rest_client.list_short_volume(ticker=symbol, limit=1, order="desc"))
+            if items:
+                item = items[0]
+                data = {
+                    "short_volume_ratio": getattr(item, "short_volume_ratio", None),
+                }
+        except Exception as e:
+            self.logger.error(f"Error fetching short volume for {symbol}: {e}")
+
+        self._short_volume_cache[symbol] = data
+        await self.redis_client.setex(redis_key, _SHORT_VOLUME_TTL, json.dumps(data))
+        return data
+
+    @tracer.start_as_current_span("eqa._get_splits")
+    async def _get_splits(self, symbol: str) -> list:
+        """Fetch recent splits via three-tier cache (memory → Redis → API).
+
+        Calls Polygon ``/v3/reference/splits?ticker={symbol}&limit=10``.
+
+        Args:
+            symbol: Ticker symbol.
+
+        Returns:
+            List of split dicts, or empty list.
+        """
+        if symbol in self._splits_cache:
+            return self._splits_cache[symbol]
+
+        redis_key = f"enrichment:splits:{symbol}"
+        cached = await self.redis_client.get(redis_key)
+        if cached:
+            data = json.loads(cached)
+            self._splits_cache[symbol] = data
+            return data
+
+        data = []
+        try:
+            items = list(self.rest_client.list_splits(ticker=symbol, limit=10))
+            for item in items:
+                data.append({
+                    "execution_date": getattr(item, "execution_date", None),
+                    "split_from": getattr(item, "split_from", None),
+                    "split_to": getattr(item, "split_to", None),
+                    "ticker": getattr(item, "ticker", None),
+                })
+        except Exception as e:
+            self.logger.error(f"Error fetching splits for {symbol}: {e}")
+
+        self._splits_cache[symbol] = data
+        await self.redis_client.setex(redis_key, _SPLITS_TTL, json.dumps(data))
+        return data

--- a/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
@@ -12,12 +12,16 @@ Session windows (Eastern Time):
 """
 import json
 import logging
+import time
 from datetime import datetime, timezone
 from typing import Optional, List
 from zoneinfo import ZoneInfo
 
+from massive.rest.models import MarketStatus
+
 from kuhl_haus.mdp.analyzers.analyzer import Analyzer, AnalyzerOptions
 from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
+from kuhl_haus.mdp.enum.market_status_value import MarketStatusValue
 from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
 from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
 from kuhl_haus.mdp.helpers.observability import get_tracer
@@ -71,6 +75,10 @@ class EnhancedQuoteAnalyzer(Analyzer):
         self._short_volume_cache: dict = {}
         self._splits_cache: dict = {}
 
+        # Market status cache (60-second TTL)
+        self._market_status: Optional[MarketStatus] = None
+        self._market_status_fetched_at: float = 0.0  # monotonic epoch seconds
+
     @tracer.start_as_current_span("eqa.analyze_data")
     async def analyze_data(self, data: dict) -> Optional[List[MarketDataAnalyzerResult]]:
         """Process a quote event and return an enriched enhanced_quote result.
@@ -96,7 +104,7 @@ class EnhancedQuoteAnalyzer(Analyzer):
         await self._check_day_boundary()
         await self._check_market_open_reset()
 
-        self._update_session_hod_lod(symbol, data)
+        await self._update_session_hod_lod(symbol, data)
 
         overview_data = await self._get_overview(symbol)
         short_interest_data = await self._get_short_interest(symbol)
@@ -134,47 +142,53 @@ class EnhancedQuoteAnalyzer(Analyzer):
             publish_key=cache_key,
         )]
 
-    def _get_session(self, start_timestamp: int) -> Optional[str]:
-        """Detect intraday session from a millisecond UTC timestamp.
+    async def _get_market_status(self) -> Optional[MarketStatus]:
+        """Fetch market status with 60-second in-memory cache.
 
-        Converts the timestamp to Eastern Time and maps it to a session window.
+        Returns stale cache on API failure rather than None — better than
+        dropping events due to a transient error.
+        """
+        now = time.monotonic()
+        if now - self._market_status_fetched_at < 60:
+            return self._market_status
+        try:
+            self._market_status = self.rest_client.get_market_status()
+            self._market_status_fetched_at = now
+        except Exception as e:
+            self.logger.warning(f"get_market_status() failed: {e}")
+            # Return stale cache — better than None
+        return self._market_status
 
-        Args:
-            start_timestamp: Event start time in milliseconds since epoch (UTC).
+    async def _get_session(self) -> Optional[str]:
+        """Determine current trading session via market status API.
+
+        Uses get_market_status() with 60-second in-memory cache. Returns None
+        if market is closed or status is unavailable.
 
         Returns:
-            ``'pre_market'``, ``'regular'``, ``'after_hours'``, or ``None``
-            if outside all session windows.
+            ``'pre_market'``, ``'regular'``, ``'after_hours'``, or ``None``.
         """
-        dt = datetime.fromtimestamp(
-            start_timestamp / 1000, tz=timezone.utc
-        ).astimezone(ZoneInfo("America/New_York"))
-        total_minutes = dt.hour * 60 + dt.minute
-
-        if 4 * 60 <= total_minutes < 9 * 60 + 30:
+        status = await self._get_market_status()
+        if status is None or status.market == MarketStatusValue.CLOSED.value:
+            return None
+        if status.early_hours:
             return "pre_market"
-        elif 9 * 60 + 30 <= total_minutes < 16 * 60:
-            return "regular"
-        elif 16 * 60 <= total_minutes < 20 * 60:
+        if status.after_hours:
             return "after_hours"
+        if status.market is not None:
+            return "regular"
         return None
 
-    def _update_session_hod_lod(self, symbol: str, data: dict):
+    async def _update_session_hod_lod(self, symbol: str, data: dict):
         """Update in-memory session high/low from the event's high/low fields.
 
-        Skips update if ``start_timestamp`` is absent or the event falls
-        outside all session windows.
+        Skips update if the market is closed or status is unavailable.
 
         Args:
             symbol: Ticker symbol.
-            data:   Quote event dict containing ``start_timestamp``, ``high``,
-                    and ``low`` fields.
+            data:   Quote event dict containing ``high`` and ``low`` fields.
         """
-        start_timestamp = data.get("start_timestamp")
-        if not start_timestamp:
-            return
-
-        session = self._get_session(start_timestamp)
+        session = await self._get_session()
         if session is None:
             return
 

--- a/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
@@ -5,10 +5,8 @@ combining real-time session high/low tracking with reference data (overview,
 short interest, short volume, splits) fetched via a three-tier cache
 (memory → Redis → REST API).
 
-Session windows (Eastern Time):
-- Pre-market:     04:00–09:30
-- Regular:        09:30–16:00
-- After-hours:    16:00–20:00
+Session detection uses the Massive ``get_market_status()`` API (60-second
+in-memory cache) so exchange holidays and early closes are handled correctly.
 """
 import json
 import logging
@@ -263,6 +261,10 @@ class EnhancedQuoteAnalyzer(Analyzer):
         """
         et_now = datetime.now(timezone.utc).astimezone(ZoneInfo("America/New_York"))
 
+        # Time-of-day is intentional here — this is a reset *trigger* that fires
+        # during the 9:30 AM ET window, not a session classifier. Exchange holidays
+        # are not a concern: if the market is closed the leaderboard data is stale
+        # anyway, and an extra pre-market clear on a holiday is harmless.
         if not (et_now.hour == 9 and 30 <= et_now.minute < 31):
             return
 

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_keys.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_keys.py
@@ -64,3 +64,6 @@ class WidgetDataCacheKeys(Enum):
     # Finlight news feeds
     NEWS_FEED_LATEST = 'news:feed:latest'
     NEWS_TICKER = 'news:ticker:{ticker}'
+
+    # Enhanced quote feed
+    ENHANCED_QUOTE = 'enhanced_quote'  # Usage: f'{ENHANCED_QUOTE.value}:{symbol}'

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
@@ -36,3 +36,6 @@ class WidgetDataCacheTTL(Enum):
     # Finlight news caches
     NEWS_FEED_LATEST = TWO_DAYS
     NEWS_TICKER = SEVEN_DAYS
+
+    # Enhanced quote cache
+    ENHANCED_QUOTE = SEVEN_DAYS  # 7 days

--- a/tests/analyzers/test_enhanced_quote_analyzer.py
+++ b/tests/analyzers/test_enhanced_quote_analyzer.py
@@ -868,7 +868,8 @@ async def test_eqa_analyze_data_payload_contains_session_hod_lod(sut):
     sut._after_hours_high["AAPL"] = 156.0
     sut._after_hours_low["AAPL"] = 150.0
 
-    data = _make_quote(symbol="AAPL", start_timestamp=REGULAR_TS)
+    # Use high < pre_high and low > pre_low so pre-populated values are preserved
+    data = _make_quote(symbol="AAPL", start_timestamp=REGULAR_TS, high=155.0, low=149.0)
     with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
          patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
          patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \

--- a/tests/analyzers/test_enhanced_quote_analyzer.py
+++ b/tests/analyzers/test_enhanced_quote_analyzer.py
@@ -1,9 +1,12 @@
 """Tests for EnhancedQuoteAnalyzer — session HOD/LOD tracking and MDS enrichment."""
 import json
+import time
 import pytest
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
+
+from massive.rest.models import MarketStatus
 
 from kuhl_haus.mdp.analyzers.enhanced_quote_analyzer import EnhancedQuoteAnalyzer
 from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
@@ -30,16 +33,6 @@ PRE_MARKET_TS = _ms(2026, 4, 8, 5, 0)     # 05:00 ET → pre-market
 REGULAR_TS = _ms(2026, 4, 8, 10, 0)       # 10:00 ET → regular session
 AFTER_HOURS_TS = _ms(2026, 4, 8, 17, 0)   # 17:00 ET → after-hours
 OUTSIDE_TS = _ms(2026, 4, 8, 23, 0)       # 23:00 ET → outside all windows
-OUTSIDE_MIDNIGHT_TS = _ms(2026, 4, 8, 1, 0)  # 01:00 ET → outside all windows
-
-# Edge timestamps
-PRE_MARKET_START_TS = _ms(2026, 4, 8, 4, 0)    # exactly 04:00 ET → pre-market
-PRE_MARKET_END_TS = _ms(2026, 4, 8, 9, 29)     # 09:29 ET → pre-market
-REGULAR_START_TS = _ms(2026, 4, 8, 9, 30)      # exactly 09:30 ET → regular
-REGULAR_END_TS = _ms(2026, 4, 8, 15, 59)       # 15:59 ET → regular
-AFTER_HOURS_START_TS = _ms(2026, 4, 8, 16, 0)  # exactly 16:00 ET → after-hours
-AFTER_HOURS_END_TS = _ms(2026, 4, 8, 19, 59)   # 19:59 ET → after-hours
-AFTER_HOURS_CLOSE_TS = _ms(2026, 4, 8, 20, 0)  # exactly 20:00 ET → outside
 
 
 # ------------------------------------------------------------------
@@ -68,6 +61,7 @@ def mock_rest_client():
     client.list_short_interest.return_value = iter([])
     client.list_short_volume.return_value = iter([])
     client.list_splits.return_value = iter([])
+    client.get_market_status.return_value = MarketStatus(market="open", early_hours=False, after_hours=False)
     return client
 
 
@@ -186,104 +180,212 @@ def test_eqa_init_creates_empty_enrichment_caches(mock_options):
     assert sut._splits_cache == {}
 
 
-# ------------------------------------------------------------------
-# _get_session — session detection from start_timestamp
-# ------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("ts,expected", [
-    (PRE_MARKET_START_TS, "pre_market"),     # 04:00 ET — start of pre-market
-    (PRE_MARKET_TS, "pre_market"),           # 05:00 ET — mid pre-market
-    (PRE_MARKET_END_TS, "pre_market"),       # 09:29 ET — last pre-market minute
-    (REGULAR_START_TS, "regular"),           # 09:30 ET — start of regular
-    (REGULAR_TS, "regular"),                 # 10:00 ET — mid regular
-    (REGULAR_END_TS, "regular"),             # 15:59 ET — last regular minute
-    (AFTER_HOURS_START_TS, "after_hours"),   # 16:00 ET — start of after-hours
-    (AFTER_HOURS_TS, "after_hours"),         # 17:00 ET — mid after-hours
-    (AFTER_HOURS_END_TS, "after_hours"),     # 19:59 ET — last after-hours minute
-    (AFTER_HOURS_CLOSE_TS, None),            # 20:00 ET — outside
-    (OUTSIDE_TS, None),                      # 23:00 ET — outside
-    (OUTSIDE_MIDNIGHT_TS, None),             # 01:00 ET — outside (pre pre-market)
-])
-def test_eqa_get_session_returns_correct_session(sut, ts, expected):
+def test_eqa_init_sets_market_status_cache_fields(mock_options):
     # Act
-    result = sut._get_session(ts)
+    sut = EnhancedQuoteAnalyzer(mock_options)
 
     # Assert
-    assert result == expected
+    assert sut._market_status is None
+    assert sut._market_status_fetched_at == 0.0
+
+
+# ------------------------------------------------------------------
+# _get_market_status — 60-second in-memory cache
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_market_status_fetches_on_first_call(sut, mock_rest_client):
+    # Arrange — cache is cold (_market_status_fetched_at = 0.0)
+    status = MarketStatus(market="open", early_hours=False, after_hours=False)
+    mock_rest_client.get_market_status.return_value = status
+
+    # Act
+    result = await sut._get_market_status()
+
+    # Assert
+    assert result is status
+    mock_rest_client.get_market_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_market_status_returns_cached_within_60s(sut, mock_rest_client):
+    # Arrange — cache is warm (fetched just now)
+    cached = MarketStatus(market="open", early_hours=False, after_hours=False)
+    sut._market_status = cached
+    sut._market_status_fetched_at = time.monotonic()
+
+    # Act
+    result = await sut._get_market_status()
+
+    # Assert — cached value returned, API not called
+    assert result is cached
+    mock_rest_client.get_market_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_market_status_refetches_after_60s(sut, mock_rest_client):
+    # Arrange — cache expired 61 seconds ago
+    old = MarketStatus(market="closed", early_hours=False, after_hours=False)
+    new = MarketStatus(market="open", early_hours=False, after_hours=False)
+    sut._market_status = old
+    sut._market_status_fetched_at = time.monotonic() - 61
+    mock_rest_client.get_market_status.return_value = new
+
+    # Act
+    result = await sut._get_market_status()
+
+    # Assert — new value fetched and cached
+    assert result is new
+    mock_rest_client.get_market_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_market_status_returns_stale_on_api_failure(sut, mock_rest_client):
+    # Arrange — cache expired, API will raise
+    stale = MarketStatus(market="open", early_hours=False, after_hours=False)
+    sut._market_status = stale
+    sut._market_status_fetched_at = 0.0
+    mock_rest_client.get_market_status.side_effect = Exception("Network error")
+
+    # Act
+    result = await sut._get_market_status()
+
+    # Assert — stale value returned, no exception raised
+    assert result is stale
+    mock_rest_client.get_market_status.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# _get_session — session detection via market status API
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_session_returns_pre_market(sut):
+    # Arrange
+    status = MarketStatus(market="extended-hours", early_hours=True, after_hours=False)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=status):
+        result = await sut._get_session()
+    assert result == "pre_market"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_session_returns_regular(sut):
+    # Arrange
+    status = MarketStatus(market="open", early_hours=False, after_hours=False)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=status):
+        result = await sut._get_session()
+    assert result == "regular"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_session_returns_after_hours(sut):
+    # Arrange
+    status = MarketStatus(market="extended-hours", early_hours=False, after_hours=True)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=status):
+        result = await sut._get_session()
+    assert result == "after_hours"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_session_returns_none_when_closed(sut):
+    # Arrange
+    status = MarketStatus(market="closed", early_hours=False, after_hours=False)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=status):
+        result = await sut._get_session()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_session_returns_none_when_status_is_none(sut):
+    # Arrange
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=None):
+        result = await sut._get_session()
+    assert result is None
 
 
 # ------------------------------------------------------------------
 # _update_session_hod_lod — HOD/LOD update logic
 # ------------------------------------------------------------------
 
+_PRE_MARKET_STATUS = MarketStatus(market="extended-hours", early_hours=True, after_hours=False)
+_REGULAR_STATUS = MarketStatus(market="open", early_hours=False, after_hours=False)
+_AFTER_HOURS_STATUS = MarketStatus(market="extended-hours", early_hours=False, after_hours=True)
+_CLOSED_STATUS = MarketStatus(market="closed", early_hours=False, after_hours=False)
 
-def test_eqa_update_hod_lod_pre_market_sets_initial_high(sut):
+
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_pre_market_sets_initial_high(sut):
     # Arrange
     data = _make_quote(start_timestamp=PRE_MARKET_TS, high=155.0, low=145.0)
 
-    # Act
-    sut._update_session_hod_lod("AAPL", data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=_PRE_MARKET_STATUS):
+        await sut._update_session_hod_lod("AAPL", data)
 
-    # Assert
     assert sut._pre_market_high["AAPL"] == 155.0
     assert sut._pre_market_low["AAPL"] == 145.0
 
 
-def test_eqa_update_hod_lod_pre_market_new_high_replaces(sut):
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_pre_market_new_high_replaces(sut):
     # Arrange
     sut._pre_market_high["AAPL"] = 150.0
     data = _make_quote(start_timestamp=PRE_MARKET_TS, high=160.0, low=149.0)
 
-    # Act
-    sut._update_session_hod_lod("AAPL", data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=_PRE_MARKET_STATUS):
+        await sut._update_session_hod_lod("AAPL", data)
 
     # Assert — new high is higher, should replace
     assert sut._pre_market_high["AAPL"] == 160.0
 
 
-def test_eqa_update_hod_lod_pre_market_lower_high_does_not_replace(sut):
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_pre_market_lower_high_does_not_replace(sut):
     # Arrange
     sut._pre_market_high["AAPL"] = 165.0
     data = _make_quote(start_timestamp=PRE_MARKET_TS, high=155.0, low=149.0)
 
-    # Act
-    sut._update_session_hod_lod("AAPL", data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=_PRE_MARKET_STATUS):
+        await sut._update_session_hod_lod("AAPL", data)
 
     # Assert — existing high is already higher, should NOT replace
     assert sut._pre_market_high["AAPL"] == 165.0
 
 
-def test_eqa_update_hod_lod_pre_market_new_low_replaces(sut):
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_pre_market_new_low_replaces(sut):
     # Arrange
     sut._pre_market_low["AAPL"] = 145.0
     data = _make_quote(start_timestamp=PRE_MARKET_TS, high=155.0, low=140.0)
 
-    # Act
-    sut._update_session_hod_lod("AAPL", data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=_PRE_MARKET_STATUS):
+        await sut._update_session_hod_lod("AAPL", data)
 
     # Assert — new low is lower, should replace
     assert sut._pre_market_low["AAPL"] == 140.0
 
 
-def test_eqa_update_hod_lod_pre_market_higher_low_does_not_replace(sut):
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_pre_market_higher_low_does_not_replace(sut):
     # Arrange
     sut._pre_market_low["AAPL"] = 140.0
     data = _make_quote(start_timestamp=PRE_MARKET_TS, high=155.0, low=148.0)
 
-    # Act
-    sut._update_session_hod_lod("AAPL", data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=_PRE_MARKET_STATUS):
+        await sut._update_session_hod_lod("AAPL", data)
 
     # Assert — existing low is already lower, should NOT replace
     assert sut._pre_market_low["AAPL"] == 140.0
 
 
-def test_eqa_update_hod_lod_regular_session_updates_correct_dicts(sut):
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_regular_session_updates_correct_dicts(sut):
     # Arrange
     data = _make_quote(start_timestamp=REGULAR_TS, high=160.0, low=150.0)
 
-    # Act
-    sut._update_session_hod_lod("TSLA", data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=_REGULAR_STATUS):
+        await sut._update_session_hod_lod("TSLA", data)
 
     # Assert — regular session dicts updated, not pre-market
     assert sut._regular_session_high["TSLA"] == 160.0
@@ -292,12 +394,13 @@ def test_eqa_update_hod_lod_regular_session_updates_correct_dicts(sut):
     assert "TSLA" not in sut._after_hours_high
 
 
-def test_eqa_update_hod_lod_after_hours_updates_correct_dicts(sut):
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_after_hours_updates_correct_dicts(sut):
     # Arrange
     data = _make_quote(start_timestamp=AFTER_HOURS_TS, high=162.0, low=158.0)
 
-    # Act
-    sut._update_session_hod_lod("NVDA", data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=_AFTER_HOURS_STATUS):
+        await sut._update_session_hod_lod("NVDA", data)
 
     # Assert — after-hours dicts updated, not others
     assert sut._after_hours_high["NVDA"] == 162.0
@@ -306,12 +409,13 @@ def test_eqa_update_hod_lod_after_hours_updates_correct_dicts(sut):
     assert "NVDA" not in sut._regular_session_high
 
 
-def test_eqa_update_hod_lod_outside_window_does_not_update(sut):
-    # Arrange
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_closed_market_does_not_update(sut):
+    # Arrange — market is closed
     data = _make_quote(start_timestamp=OUTSIDE_TS, high=160.0, low=150.0)
 
-    # Act
-    sut._update_session_hod_lod("MSFT", data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=_CLOSED_STATUS):
+        await sut._update_session_hod_lod("MSFT", data)
 
     # Assert — no session dict should be updated
     assert "MSFT" not in sut._pre_market_high
@@ -319,12 +423,13 @@ def test_eqa_update_hod_lod_outside_window_does_not_update(sut):
     assert "MSFT" not in sut._after_hours_high
 
 
-def test_eqa_update_hod_lod_missing_start_timestamp_does_not_update(sut):
-    # Arrange — no start_timestamp
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_unavailable_market_status_does_not_update(sut):
+    # Arrange — market status unavailable (None)
     data = {"symbol": "AAPL", "high": 160.0, "low": 150.0}
 
-    # Act
-    sut._update_session_hod_lod("AAPL", data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=None):
+        await sut._update_session_hod_lod("AAPL", data)
 
     # Assert — no dicts updated
     assert "AAPL" not in sut._pre_market_high
@@ -332,27 +437,29 @@ def test_eqa_update_hod_lod_missing_start_timestamp_does_not_update(sut):
     assert "AAPL" not in sut._after_hours_high
 
 
-def test_eqa_update_hod_lod_none_high_skips_high_update(sut):
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_none_high_skips_high_update(sut):
     # Arrange — high is None, only low is present
     sut._regular_session_high["AAPL"] = 150.0
     data = _make_quote(start_timestamp=REGULAR_TS, high=None, low=140.0)
 
-    # Act
-    sut._update_session_hod_lod("AAPL", data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=_REGULAR_STATUS):
+        await sut._update_session_hod_lod("AAPL", data)
 
     # Assert — high unchanged, low updated
     assert sut._regular_session_high["AAPL"] == 150.0
     assert sut._regular_session_low["AAPL"] == 140.0
 
 
-def test_eqa_update_hod_lod_multiple_symbols_tracked_independently(sut):
+@pytest.mark.asyncio
+async def test_eqa_update_hod_lod_multiple_symbols_tracked_independently(sut):
     # Arrange
     aapl_data = _make_quote(symbol="AAPL", start_timestamp=REGULAR_TS, high=155.0, low=145.0)
     tsla_data = _make_quote(symbol="TSLA", start_timestamp=REGULAR_TS, high=800.0, low=780.0)
 
-    # Act
-    sut._update_session_hod_lod("AAPL", aapl_data)
-    sut._update_session_hod_lod("TSLA", tsla_data)
+    with patch.object(sut, "_get_market_status", new_callable=AsyncMock, return_value=_REGULAR_STATUS):
+        await sut._update_session_hod_lod("AAPL", aapl_data)
+        await sut._update_session_hod_lod("TSLA", tsla_data)
 
     # Assert — symbols tracked independently
     assert sut._regular_session_high["AAPL"] == 155.0

--- a/tests/analyzers/test_enhanced_quote_analyzer.py
+++ b/tests/analyzers/test_enhanced_quote_analyzer.py
@@ -1,0 +1,1080 @@
+"""Tests for EnhancedQuoteAnalyzer — session HOD/LOD tracking and MDS enrichment."""
+import json
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
+
+from kuhl_haus.mdp.analyzers.enhanced_quote_analyzer import EnhancedQuoteAnalyzer
+from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
+from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
+from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
+
+
+MODULE = "kuhl_haus.mdp.analyzers.enhanced_quote_analyzer"
+
+ET = ZoneInfo("America/New_York")
+
+
+def _ms(year, month, day, hour, minute, tz=ET):
+    """Return millisecond timestamp for a given ET datetime."""
+    return int(datetime(year, month, day, hour, minute, 0, tzinfo=tz).timestamp() * 1000)
+
+
+# ------------------------------------------------------------------
+# Timestamp helpers (all April 2026, EDT = UTC-4)
+# ------------------------------------------------------------------
+
+PRE_MARKET_TS = _ms(2026, 4, 8, 5, 0)     # 05:00 ET → pre-market
+REGULAR_TS = _ms(2026, 4, 8, 10, 0)       # 10:00 ET → regular session
+AFTER_HOURS_TS = _ms(2026, 4, 8, 17, 0)   # 17:00 ET → after-hours
+OUTSIDE_TS = _ms(2026, 4, 8, 23, 0)       # 23:00 ET → outside all windows
+OUTSIDE_MIDNIGHT_TS = _ms(2026, 4, 8, 1, 0)  # 01:00 ET → outside all windows
+
+# Edge timestamps
+PRE_MARKET_START_TS = _ms(2026, 4, 8, 4, 0)    # exactly 04:00 ET → pre-market
+PRE_MARKET_END_TS = _ms(2026, 4, 8, 9, 29)     # 09:29 ET → pre-market
+REGULAR_START_TS = _ms(2026, 4, 8, 9, 30)      # exactly 09:30 ET → regular
+REGULAR_END_TS = _ms(2026, 4, 8, 15, 59)       # 15:59 ET → regular
+AFTER_HOURS_START_TS = _ms(2026, 4, 8, 16, 0)  # exactly 16:00 ET → after-hours
+AFTER_HOURS_END_TS = _ms(2026, 4, 8, 19, 59)   # 19:59 ET → after-hours
+AFTER_HOURS_CLOSE_TS = _ms(2026, 4, 8, 20, 0)  # exactly 20:00 ET → outside
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_redis():
+    """Mock async Redis client."""
+    redis = MagicMock()
+    redis.eval = AsyncMock(return_value=0)
+    redis.set = AsyncMock(return_value=None)
+    redis.get = AsyncMock(return_value=None)
+    redis.setex = AsyncMock()
+    return redis
+
+
+@pytest.fixture
+def mock_rest_client():
+    """Mock REST client with empty default responses."""
+    client = MagicMock()
+    overview_result = MagicMock()
+    overview_result.results = None
+    client.get_ticker_details.return_value = overview_result
+    client.list_short_interest.return_value = iter([])
+    client.list_short_volume.return_value = iter([])
+    client.list_splits.return_value = iter([])
+    return client
+
+
+@pytest.fixture
+def mock_options(mock_redis, mock_rest_client):
+    """Mock AnalyzerOptions that returns mock clients."""
+    opts = MagicMock(spec=AnalyzerOptions)
+    opts.new_redis_client.return_value = mock_redis
+    opts.new_rest_client.return_value = mock_rest_client
+    return opts
+
+
+@pytest.fixture
+def sut(mock_options):
+    """EnhancedQuoteAnalyzer under test."""
+    return EnhancedQuoteAnalyzer(mock_options)
+
+
+def _make_quote(symbol="AAPL", start_timestamp=REGULAR_TS, high=155.0, low=145.0, **extra):
+    """Build a minimal quote data dict."""
+    return {
+        "symbol": symbol,
+        "start_timestamp": start_timestamp,
+        "high": high,
+        "low": low,
+        "close": 150.0,
+        **extra,
+    }
+
+
+def _make_overview_result(
+    name="Apple Inc.",
+    description="Apple makes devices.",
+    homepage_url="https://apple.com",
+    list_date="1980-12-12",
+    market_cap=3_000_000_000_000,
+    primary_exchange="XNAS",
+    sic_description="Electronic Computers",
+    total_employees=164_000,
+    share_class_shares_outstanding=15_550_000_000,
+):
+    """Build a mock ticker details response."""
+    results = MagicMock()
+    results.name = name
+    results.description = description
+    results.homepage_url = homepage_url
+    results.list_date = list_date
+    results.market_cap = market_cap
+    results.primary_exchange = primary_exchange
+    results.sic_description = sic_description
+    results.total_employees = total_employees
+    results.share_class_shares_outstanding = share_class_shares_outstanding
+    response = MagicMock()
+    response.results = results
+    return response
+
+
+def _make_short_interest_item(short_interest=1_000_000, days_to_cover=2.5):
+    item = MagicMock()
+    item.short_interest = short_interest
+    item.days_to_cover = days_to_cover
+    return item
+
+
+def _make_short_volume_item(short_volume_ratio=0.35):
+    item = MagicMock()
+    item.short_volume_ratio = short_volume_ratio
+    return item
+
+
+def _make_split_item(execution_date="2020-08-31", split_from=1, split_to=4, ticker="AAPL"):
+    item = MagicMock()
+    item.execution_date = execution_date
+    item.split_from = split_from
+    item.split_to = split_to
+    item.ticker = ticker
+    return item
+
+
+# ------------------------------------------------------------------
+# Initialization
+# ------------------------------------------------------------------
+
+
+def test_eqa_init_sets_redis_and_rest_clients(mock_options):
+    # Act
+    sut = EnhancedQuoteAnalyzer(mock_options)
+
+    # Assert
+    assert sut.redis_client is mock_options.new_redis_client.return_value
+    assert sut.rest_client is mock_options.new_rest_client.return_value
+    assert sut.options is mock_options
+
+
+def test_eqa_init_creates_empty_hod_lod_dicts(mock_options):
+    # Act
+    sut = EnhancedQuoteAnalyzer(mock_options)
+
+    # Assert — all 6 session dicts start empty
+    assert sut._pre_market_high == {}
+    assert sut._pre_market_low == {}
+    assert sut._regular_session_high == {}
+    assert sut._regular_session_low == {}
+    assert sut._after_hours_high == {}
+    assert sut._after_hours_low == {}
+
+
+def test_eqa_init_creates_empty_enrichment_caches(mock_options):
+    # Act
+    sut = EnhancedQuoteAnalyzer(mock_options)
+
+    # Assert
+    assert sut._overview_cache == {}
+    assert sut._short_interest_cache == {}
+    assert sut._short_volume_cache == {}
+    assert sut._splits_cache == {}
+
+
+# ------------------------------------------------------------------
+# _get_session — session detection from start_timestamp
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ts,expected", [
+    (PRE_MARKET_START_TS, "pre_market"),     # 04:00 ET — start of pre-market
+    (PRE_MARKET_TS, "pre_market"),           # 05:00 ET — mid pre-market
+    (PRE_MARKET_END_TS, "pre_market"),       # 09:29 ET — last pre-market minute
+    (REGULAR_START_TS, "regular"),           # 09:30 ET — start of regular
+    (REGULAR_TS, "regular"),                 # 10:00 ET — mid regular
+    (REGULAR_END_TS, "regular"),             # 15:59 ET — last regular minute
+    (AFTER_HOURS_START_TS, "after_hours"),   # 16:00 ET — start of after-hours
+    (AFTER_HOURS_TS, "after_hours"),         # 17:00 ET — mid after-hours
+    (AFTER_HOURS_END_TS, "after_hours"),     # 19:59 ET — last after-hours minute
+    (AFTER_HOURS_CLOSE_TS, None),            # 20:00 ET — outside
+    (OUTSIDE_TS, None),                      # 23:00 ET — outside
+    (OUTSIDE_MIDNIGHT_TS, None),             # 01:00 ET — outside (pre pre-market)
+])
+def test_eqa_get_session_returns_correct_session(sut, ts, expected):
+    # Act
+    result = sut._get_session(ts)
+
+    # Assert
+    assert result == expected
+
+
+# ------------------------------------------------------------------
+# _update_session_hod_lod — HOD/LOD update logic
+# ------------------------------------------------------------------
+
+
+def test_eqa_update_hod_lod_pre_market_sets_initial_high(sut):
+    # Arrange
+    data = _make_quote(start_timestamp=PRE_MARKET_TS, high=155.0, low=145.0)
+
+    # Act
+    sut._update_session_hod_lod("AAPL", data)
+
+    # Assert
+    assert sut._pre_market_high["AAPL"] == 155.0
+    assert sut._pre_market_low["AAPL"] == 145.0
+
+
+def test_eqa_update_hod_lod_pre_market_new_high_replaces(sut):
+    # Arrange
+    sut._pre_market_high["AAPL"] = 150.0
+    data = _make_quote(start_timestamp=PRE_MARKET_TS, high=160.0, low=149.0)
+
+    # Act
+    sut._update_session_hod_lod("AAPL", data)
+
+    # Assert — new high is higher, should replace
+    assert sut._pre_market_high["AAPL"] == 160.0
+
+
+def test_eqa_update_hod_lod_pre_market_lower_high_does_not_replace(sut):
+    # Arrange
+    sut._pre_market_high["AAPL"] = 165.0
+    data = _make_quote(start_timestamp=PRE_MARKET_TS, high=155.0, low=149.0)
+
+    # Act
+    sut._update_session_hod_lod("AAPL", data)
+
+    # Assert — existing high is already higher, should NOT replace
+    assert sut._pre_market_high["AAPL"] == 165.0
+
+
+def test_eqa_update_hod_lod_pre_market_new_low_replaces(sut):
+    # Arrange
+    sut._pre_market_low["AAPL"] = 145.0
+    data = _make_quote(start_timestamp=PRE_MARKET_TS, high=155.0, low=140.0)
+
+    # Act
+    sut._update_session_hod_lod("AAPL", data)
+
+    # Assert — new low is lower, should replace
+    assert sut._pre_market_low["AAPL"] == 140.0
+
+
+def test_eqa_update_hod_lod_pre_market_higher_low_does_not_replace(sut):
+    # Arrange
+    sut._pre_market_low["AAPL"] = 140.0
+    data = _make_quote(start_timestamp=PRE_MARKET_TS, high=155.0, low=148.0)
+
+    # Act
+    sut._update_session_hod_lod("AAPL", data)
+
+    # Assert — existing low is already lower, should NOT replace
+    assert sut._pre_market_low["AAPL"] == 140.0
+
+
+def test_eqa_update_hod_lod_regular_session_updates_correct_dicts(sut):
+    # Arrange
+    data = _make_quote(start_timestamp=REGULAR_TS, high=160.0, low=150.0)
+
+    # Act
+    sut._update_session_hod_lod("TSLA", data)
+
+    # Assert — regular session dicts updated, not pre-market
+    assert sut._regular_session_high["TSLA"] == 160.0
+    assert sut._regular_session_low["TSLA"] == 150.0
+    assert "TSLA" not in sut._pre_market_high
+    assert "TSLA" not in sut._after_hours_high
+
+
+def test_eqa_update_hod_lod_after_hours_updates_correct_dicts(sut):
+    # Arrange
+    data = _make_quote(start_timestamp=AFTER_HOURS_TS, high=162.0, low=158.0)
+
+    # Act
+    sut._update_session_hod_lod("NVDA", data)
+
+    # Assert — after-hours dicts updated, not others
+    assert sut._after_hours_high["NVDA"] == 162.0
+    assert sut._after_hours_low["NVDA"] == 158.0
+    assert "NVDA" not in sut._pre_market_high
+    assert "NVDA" not in sut._regular_session_high
+
+
+def test_eqa_update_hod_lod_outside_window_does_not_update(sut):
+    # Arrange
+    data = _make_quote(start_timestamp=OUTSIDE_TS, high=160.0, low=150.0)
+
+    # Act
+    sut._update_session_hod_lod("MSFT", data)
+
+    # Assert — no session dict should be updated
+    assert "MSFT" not in sut._pre_market_high
+    assert "MSFT" not in sut._regular_session_high
+    assert "MSFT" not in sut._after_hours_high
+
+
+def test_eqa_update_hod_lod_missing_start_timestamp_does_not_update(sut):
+    # Arrange — no start_timestamp
+    data = {"symbol": "AAPL", "high": 160.0, "low": 150.0}
+
+    # Act
+    sut._update_session_hod_lod("AAPL", data)
+
+    # Assert — no dicts updated
+    assert "AAPL" not in sut._pre_market_high
+    assert "AAPL" not in sut._regular_session_high
+    assert "AAPL" not in sut._after_hours_high
+
+
+def test_eqa_update_hod_lod_none_high_skips_high_update(sut):
+    # Arrange — high is None, only low is present
+    sut._regular_session_high["AAPL"] = 150.0
+    data = _make_quote(start_timestamp=REGULAR_TS, high=None, low=140.0)
+
+    # Act
+    sut._update_session_hod_lod("AAPL", data)
+
+    # Assert — high unchanged, low updated
+    assert sut._regular_session_high["AAPL"] == 150.0
+    assert sut._regular_session_low["AAPL"] == 140.0
+
+
+def test_eqa_update_hod_lod_multiple_symbols_tracked_independently(sut):
+    # Arrange
+    aapl_data = _make_quote(symbol="AAPL", start_timestamp=REGULAR_TS, high=155.0, low=145.0)
+    tsla_data = _make_quote(symbol="TSLA", start_timestamp=REGULAR_TS, high=800.0, low=780.0)
+
+    # Act
+    sut._update_session_hod_lod("AAPL", aapl_data)
+    sut._update_session_hod_lod("TSLA", tsla_data)
+
+    # Assert — symbols tracked independently
+    assert sut._regular_session_high["AAPL"] == 155.0
+    assert sut._regular_session_high["TSLA"] == 800.0
+    assert sut._regular_session_low["AAPL"] == 145.0
+    assert sut._regular_session_low["TSLA"] == 780.0
+
+
+# ------------------------------------------------------------------
+# _check_day_boundary — 4 AM ET atomic reset
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eqa_check_day_boundary_on_new_day_clears_all_six_dicts(sut, mock_redis):
+    # Arrange — Lua script returns 1 (new day detected)
+    mock_redis.eval.return_value = 1
+    sut._pre_market_high["AAPL"] = 155.0
+    sut._pre_market_low["AAPL"] = 145.0
+    sut._regular_session_high["AAPL"] = 160.0
+    sut._regular_session_low["AAPL"] = 148.0
+    sut._after_hours_high["AAPL"] = 157.0
+    sut._after_hours_low["AAPL"] = 151.0
+
+    # Act
+    await sut._check_day_boundary()
+
+    # Assert — all 6 dicts cleared
+    assert sut._pre_market_high == {}
+    assert sut._pre_market_low == {}
+    assert sut._regular_session_high == {}
+    assert sut._regular_session_low == {}
+    assert sut._after_hours_high == {}
+    assert sut._after_hours_low == {}
+
+
+@pytest.mark.asyncio
+async def test_eqa_check_day_boundary_same_day_does_not_clear_dicts(sut, mock_redis):
+    # Arrange — Lua script returns 0 (same day, no reset needed)
+    mock_redis.eval.return_value = 0
+    sut._pre_market_high["AAPL"] = 155.0
+    sut._regular_session_high["AAPL"] = 160.0
+
+    # Act
+    await sut._check_day_boundary()
+
+    # Assert — dicts preserved
+    assert sut._pre_market_high["AAPL"] == 155.0
+    assert sut._regular_session_high["AAPL"] == 160.0
+
+
+@pytest.mark.asyncio
+async def test_eqa_check_day_boundary_calls_lua_with_correct_key(sut, mock_redis):
+    # Act
+    await sut._check_day_boundary()
+
+    # Assert — eval called with day boundary key
+    mock_redis.eval.assert_awaited_once()
+    call_args = mock_redis.eval.call_args
+    # KEYS[1] is the day boundary key
+    assert "enhanced_quote:day_boundary" in call_args.args
+
+
+# ------------------------------------------------------------------
+# _check_market_open_reset — 9:30 AM ET pre-market clear
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eqa_check_market_open_reset_outside_window_is_noop(sut, mock_redis):
+    # Arrange — not 9:30 AM ET
+    fake_et = datetime(2026, 4, 8, 10, 0, 0, tzinfo=ET)
+    fake_utc = fake_et.astimezone(__import__("datetime").timezone.utc)
+
+    with patch(f"{MODULE}.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_utc
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+        # Act
+        await sut._check_market_open_reset()
+
+    # Assert — no Redis calls
+    mock_redis.set.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_eqa_check_market_open_reset_at_930_wins_race_clears_premarket(sut, mock_redis):
+    # Arrange — 9:30 AM ET, nx=True wins
+    fake_et = datetime(2026, 4, 8, 9, 30, 0, tzinfo=ET)
+    fake_utc = fake_et.astimezone(__import__("datetime").timezone.utc)
+    mock_redis.set.return_value = True
+    sut._pre_market_high["AAPL"] = 155.0
+    sut._pre_market_low["AAPL"] = 145.0
+    sut._regular_session_high["AAPL"] = 160.0
+
+    with patch(f"{MODULE}.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_utc
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+        # Act
+        await sut._check_market_open_reset()
+
+    # Assert — pre-market dicts cleared, regular untouched
+    assert sut._pre_market_high == {}
+    assert sut._pre_market_low == {}
+    assert sut._regular_session_high["AAPL"] == 160.0
+
+
+@pytest.mark.asyncio
+async def test_eqa_check_market_open_reset_at_930_loses_race_does_not_clear(sut, mock_redis):
+    # Arrange — 9:30 AM ET, nx=True fails (key already exists)
+    fake_et = datetime(2026, 4, 8, 9, 30, 0, tzinfo=ET)
+    fake_utc = fake_et.astimezone(__import__("datetime").timezone.utc)
+    mock_redis.set.return_value = None  # nx=True failed
+    sut._pre_market_high["AAPL"] = 155.0
+    sut._pre_market_low["AAPL"] = 145.0
+
+    with patch(f"{MODULE}.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_utc
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+        # Act
+        await sut._check_market_open_reset()
+
+    # Assert — pre-market dicts NOT cleared (another instance already did it)
+    assert sut._pre_market_high["AAPL"] == 155.0
+    assert sut._pre_market_low["AAPL"] == 145.0
+
+
+@pytest.mark.asyncio
+async def test_eqa_check_market_open_reset_only_clears_premarket_not_regular_or_after_hours(sut, mock_redis):
+    # Arrange — 9:30 AM ET, wins race
+    fake_et = datetime(2026, 4, 8, 9, 30, 0, tzinfo=ET)
+    fake_utc = fake_et.astimezone(__import__("datetime").timezone.utc)
+    mock_redis.set.return_value = True
+    sut._pre_market_high["AAPL"] = 155.0
+    sut._pre_market_low["AAPL"] = 145.0
+    sut._regular_session_high["AAPL"] = 162.0
+    sut._regular_session_low["AAPL"] = 148.0
+    sut._after_hours_high["AAPL"] = 158.0
+    sut._after_hours_low["AAPL"] = 152.0
+
+    with patch(f"{MODULE}.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_utc
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+        # Act
+        await sut._check_market_open_reset()
+
+    # Assert — only pre-market cleared
+    assert sut._pre_market_high == {}
+    assert sut._pre_market_low == {}
+    assert sut._regular_session_high["AAPL"] == 162.0
+    assert sut._regular_session_low["AAPL"] == 148.0
+    assert sut._after_hours_high["AAPL"] == 158.0
+    assert sut._after_hours_low["AAPL"] == 152.0
+
+
+# ------------------------------------------------------------------
+# Three-tier enrichment cache — _get_overview
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_memory_hit_skips_redis_and_api(sut, mock_redis, mock_rest_client):
+    # Arrange — memory already populated
+    sut._overview_cache["AAPL"] = {"name": "Apple Inc."}
+
+    # Act
+    result = await sut._get_overview("AAPL")
+
+    # Assert — memory returned, no Redis or API calls
+    assert result == {"name": "Apple Inc."}
+    mock_redis.get.assert_not_awaited()
+    mock_rest_client.get_ticker_details.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_redis_hit_skips_api_and_populates_memory(sut, mock_redis, mock_rest_client):
+    # Arrange — Redis has cached data
+    cached = {"name": "Apple Inc.", "description": "Apple makes devices."}
+    mock_redis.get.return_value = json.dumps(cached)
+
+    # Act
+    result = await sut._get_overview("AAPL")
+
+    # Assert — Redis data returned, API not called, memory populated
+    assert result == cached
+    mock_rest_client.get_ticker_details.assert_not_called()
+    assert sut._overview_cache["AAPL"] == cached
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_api_hit_writes_redis_and_memory(sut, mock_redis, mock_rest_client):
+    # Arrange — Redis miss, API returns data
+    mock_redis.get.return_value = None
+    mock_rest_client.get_ticker_details.return_value = _make_overview_result()
+
+    # Act
+    result = await sut._get_overview("AAPL")
+
+    # Assert — API called, result cached in Redis and memory
+    assert result["name"] == "Apple Inc."
+    assert result["description"] == "Apple makes devices."
+    assert result["primary_exchange"] == "XNAS"
+    mock_redis.setex.assert_awaited_once()
+    assert sut._overview_cache["AAPL"]["name"] == "Apple Inc."
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_api_error_returns_empty_dict(sut, mock_redis, mock_rest_client):
+    # Arrange — Redis miss, API raises exception
+    mock_redis.get.return_value = None
+    mock_rest_client.get_ticker_details.side_effect = Exception("API error")
+
+    # Act
+    result = await sut._get_overview("AAPL")
+
+    # Assert — empty dict returned, no crash
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_api_none_results_returns_empty_dict(sut, mock_redis, mock_rest_client):
+    # Arrange — API returns response with results=None
+    mock_redis.get.return_value = None
+    overview_response = MagicMock()
+    overview_response.results = None
+    mock_rest_client.get_ticker_details.return_value = overview_response
+
+    # Act
+    result = await sut._get_overview("AAPL")
+
+    # Assert — empty dict returned
+    assert result == {}
+
+
+# ------------------------------------------------------------------
+# Three-tier enrichment cache — _get_short_interest
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_interest_memory_hit_skips_redis_and_api(sut, mock_redis, mock_rest_client):
+    # Arrange
+    sut._short_interest_cache["AAPL"] = {"short_interest": 1_000_000, "days_to_cover": 2.5}
+
+    # Act
+    result = await sut._get_short_interest("AAPL")
+
+    # Assert
+    assert result["short_interest"] == 1_000_000
+    mock_redis.get.assert_not_awaited()
+    mock_rest_client.list_short_interest.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_interest_redis_hit_skips_api(sut, mock_redis, mock_rest_client):
+    # Arrange
+    cached = {"short_interest": 500_000, "days_to_cover": 1.8}
+    mock_redis.get.return_value = json.dumps(cached)
+
+    # Act
+    result = await sut._get_short_interest("AAPL")
+
+    # Assert
+    assert result == cached
+    mock_rest_client.list_short_interest.assert_not_called()
+    assert sut._short_interest_cache["AAPL"] == cached
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_interest_api_hit_writes_redis_and_memory(sut, mock_redis, mock_rest_client):
+    # Arrange
+    mock_redis.get.return_value = None
+    item = _make_short_interest_item(short_interest=1_234_567, days_to_cover=3.2)
+    mock_rest_client.list_short_interest.return_value = iter([item])
+
+    # Act
+    result = await sut._get_short_interest("AAPL")
+
+    # Assert
+    assert result["short_interest"] == 1_234_567
+    assert result["days_to_cover"] == 3.2
+    mock_redis.setex.assert_awaited_once()
+    assert sut._short_interest_cache["AAPL"]["short_interest"] == 1_234_567
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_interest_empty_api_response_returns_empty_dict(sut, mock_redis, mock_rest_client):
+    # Arrange
+    mock_redis.get.return_value = None
+    mock_rest_client.list_short_interest.return_value = iter([])
+
+    # Act
+    result = await sut._get_short_interest("AAPL")
+
+    # Assert
+    assert result == {}
+
+
+# ------------------------------------------------------------------
+# Three-tier enrichment cache — _get_short_volume
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_volume_memory_hit_skips_redis_and_api(sut, mock_redis, mock_rest_client):
+    # Arrange
+    sut._short_volume_cache["AAPL"] = {"short_volume_ratio": 0.42}
+
+    # Act
+    result = await sut._get_short_volume("AAPL")
+
+    # Assert
+    assert result["short_volume_ratio"] == 0.42
+    mock_redis.get.assert_not_awaited()
+    mock_rest_client.list_short_volume.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_volume_redis_hit_skips_api(sut, mock_redis, mock_rest_client):
+    # Arrange
+    cached = {"short_volume_ratio": 0.31}
+    mock_redis.get.return_value = json.dumps(cached)
+
+    # Act
+    result = await sut._get_short_volume("AAPL")
+
+    # Assert
+    assert result == cached
+    mock_rest_client.list_short_volume.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_volume_api_hit_writes_redis_and_memory(sut, mock_redis, mock_rest_client):
+    # Arrange
+    mock_redis.get.return_value = None
+    item = _make_short_volume_item(short_volume_ratio=0.35)
+    mock_rest_client.list_short_volume.return_value = iter([item])
+
+    # Act
+    result = await sut._get_short_volume("AAPL")
+
+    # Assert
+    assert result["short_volume_ratio"] == 0.35
+    mock_redis.setex.assert_awaited_once()
+    assert sut._short_volume_cache["AAPL"]["short_volume_ratio"] == 0.35
+
+
+# ------------------------------------------------------------------
+# Three-tier enrichment cache — _get_splits
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_splits_memory_hit_skips_redis_and_api(sut, mock_redis, mock_rest_client):
+    # Arrange
+    sut._splits_cache["AAPL"] = [{"execution_date": "2020-08-31", "split_to": 4}]
+
+    # Act
+    result = await sut._get_splits("AAPL")
+
+    # Assert
+    assert len(result) == 1
+    assert result[0]["split_to"] == 4
+    mock_redis.get.assert_not_awaited()
+    mock_rest_client.list_splits.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_splits_redis_hit_skips_api(sut, mock_redis, mock_rest_client):
+    # Arrange
+    cached = [{"execution_date": "2020-08-31", "split_to": 4, "split_from": 1, "ticker": "AAPL"}]
+    mock_redis.get.return_value = json.dumps(cached)
+
+    # Act
+    result = await sut._get_splits("AAPL")
+
+    # Assert
+    assert result == cached
+    mock_rest_client.list_splits.assert_not_called()
+    assert sut._splits_cache["AAPL"] == cached
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_splits_api_hit_writes_redis_and_memory(sut, mock_redis, mock_rest_client):
+    # Arrange
+    mock_redis.get.return_value = None
+    item = _make_split_item(execution_date="2020-08-31", split_from=1, split_to=4, ticker="AAPL")
+    mock_rest_client.list_splits.return_value = iter([item])
+
+    # Act
+    result = await sut._get_splits("AAPL")
+
+    # Assert
+    assert len(result) == 1
+    assert result[0]["execution_date"] == "2020-08-31"
+    assert result[0]["split_to"] == 4
+    mock_redis.setex.assert_awaited_once()
+    assert len(sut._splits_cache["AAPL"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_splits_empty_api_response_returns_empty_list(sut, mock_redis, mock_rest_client):
+    # Arrange
+    mock_redis.get.return_value = None
+    mock_rest_client.list_splits.return_value = iter([])
+
+    # Act
+    result = await sut._get_splits("AAPL")
+
+    # Assert
+    assert result == []
+
+
+# ------------------------------------------------------------------
+# analyze_data — integration
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_missing_symbol_returns_none(sut):
+    # Act
+    result = await sut.analyze_data({})
+
+    # Assert
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_none_symbol_returns_none(sut):
+    # Act
+    result = await sut.analyze_data({"symbol": None, "close": 150.0})
+
+    # Assert
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_returns_single_result(sut):
+    # Arrange
+    data = _make_quote()
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    # Assert
+    assert result is not None
+    assert len(result) == 1
+    assert isinstance(result[0], MarketDataAnalyzerResult)
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_result_has_correct_cache_key(sut):
+    # Arrange
+    data = _make_quote(symbol="AAPL")
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    # Assert
+    assert result[0].cache_key == f"{WidgetDataCacheKeys.ENHANCED_QUOTE.value}:AAPL"
+    assert result[0].publish_key == f"{WidgetDataCacheKeys.ENHANCED_QUOTE.value}:AAPL"
+    assert result[0].cache_ttl == WidgetDataCacheTTL.ENHANCED_QUOTE.value
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_payload_contains_all_raw_quote_fields(sut):
+    # Arrange — include extra fields that should pass through
+    data = _make_quote(
+        symbol="AAPL",
+        start_timestamp=REGULAR_TS,
+        high=155.0,
+        low=145.0,
+        close=150.0,
+        volume=1_000_000,
+        vwap=151.5,
+        accumulated_volume=5_000_000,
+    )
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    # Assert — raw fields passed through
+    payload = result[0].data
+    assert payload["symbol"] == "AAPL"
+    assert payload["close"] == 150.0
+    assert payload["volume"] == 1_000_000
+    assert payload["vwap"] == 151.5
+    assert payload["accumulated_volume"] == 5_000_000
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_payload_contains_session_hod_lod(sut):
+    # Arrange — pre-populate session H/L
+    sut._pre_market_high["AAPL"] = 154.0
+    sut._pre_market_low["AAPL"] = 144.0
+    sut._regular_session_high["AAPL"] = 158.0
+    sut._regular_session_low["AAPL"] = 148.0
+    sut._after_hours_high["AAPL"] = 156.0
+    sut._after_hours_low["AAPL"] = 150.0
+
+    data = _make_quote(symbol="AAPL", start_timestamp=REGULAR_TS)
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    payload = result[0].data
+    assert payload["pre_market_high"] == 154.0
+    assert payload["pre_market_low"] == 144.0
+    assert payload["regular_session_high"] == 158.0
+    assert payload["regular_session_low"] == 148.0
+    assert payload["after_hours_high"] == 156.0
+    assert payload["after_hours_low"] == 150.0
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_payload_session_hod_lod_none_when_not_set(sut):
+    # Arrange — no session data accumulated yet for this symbol
+    data = _make_quote(symbol="NEWSTOCK", start_timestamp=REGULAR_TS)
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    payload = result[0].data
+    assert payload["pre_market_high"] is None
+    assert payload["pre_market_low"] is None
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_payload_contains_overview_fields(sut):
+    # Arrange
+    overview = {
+        "name": "Apple Inc.",
+        "description": "Apple makes devices.",
+        "homepage_url": "https://apple.com",
+        "list_date": "1980-12-12",
+        "market_cap": 3_000_000_000_000,
+        "primary_exchange": "XNAS",
+        "sic_description": "Electronic Computers",
+        "total_employees": 164_000,
+        "share_class_shares_outstanding": 15_550_000_000,
+    }
+    data = _make_quote(symbol="AAPL")
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value=overview), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    payload = result[0].data
+    assert payload["name"] == "Apple Inc."
+    assert payload["description"] == "Apple makes devices."
+    assert payload["homepage_url"] == "https://apple.com"
+    assert payload["list_date"] == "1980-12-12"
+    assert payload["market_cap"] == 3_000_000_000_000
+    assert payload["primary_exchange"] == "XNAS"
+    assert payload["sic_description"] == "Electronic Computers"
+    assert payload["total_employees"] == 164_000
+    assert payload["share_class_shares_outstanding"] == 15_550_000_000
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_payload_contains_short_interest_fields(sut):
+    # Arrange
+    short_interest = {"short_interest": 1_234_567, "days_to_cover": 3.2}
+    data = _make_quote(symbol="AAPL")
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value=short_interest), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    payload = result[0].data
+    assert payload["short_interest"] == 1_234_567
+    assert payload["days_to_cover"] == 3.2
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_payload_contains_short_volume_field(sut):
+    # Arrange
+    short_volume = {"short_volume_ratio": 0.35}
+    data = _make_quote(symbol="AAPL")
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value=short_volume), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    payload = result[0].data
+    assert payload["short_volume_ratio"] == 0.35
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_payload_contains_splits(sut):
+    # Arrange
+    splits = [{"execution_date": "2020-08-31", "split_from": 1, "split_to": 4, "ticker": "AAPL"}]
+    data = _make_quote(symbol="AAPL")
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=splits):
+        result = await sut.analyze_data(data)
+
+    payload = result[0].data
+    assert payload["splits"] == splits
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_splits_defaults_to_empty_list_when_none(sut):
+    # Arrange — splits returns empty list
+    data = _make_quote(symbol="AAPL")
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    assert result[0].data["splits"] == []
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_enrichment_fields_none_when_empty_dicts(sut):
+    # Arrange — all enrichment returns empty dicts
+    data = _make_quote(symbol="AAPL")
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    payload = result[0].data
+    assert payload["name"] is None
+    assert payload["description"] is None
+    assert payload["short_interest"] is None
+    assert payload["days_to_cover"] is None
+    assert payload["short_volume_ratio"] is None
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_calls_boundary_checks(sut):
+    # Arrange
+    data = _make_quote()
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock) as mock_day, \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock) as mock_open, \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        await sut.analyze_data(data)
+
+    # Assert — both boundary checks called
+    mock_day.assert_awaited_once()
+    mock_open.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_updates_hod_lod_before_building_payload(sut):
+    """analyze_data must update HOD/LOD from event before building the payload."""
+    # Arrange — no prior state; data has a regular-session high
+    data = _make_quote(symbol="AAPL", start_timestamp=REGULAR_TS, high=170.0, low=160.0)
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}), \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]):
+        result = await sut.analyze_data(data)
+
+    # Assert — HOD/LOD from this event reflected in payload
+    payload = result[0].data
+    assert payload["regular_session_high"] == 170.0
+    assert payload["regular_session_low"] == 160.0
+
+
+@pytest.mark.asyncio
+async def test_eqa_analyze_data_enrichment_calls_use_correct_symbol(sut):
+    # Arrange
+    data = _make_quote(symbol="TSLA")
+    with patch.object(sut, "_check_day_boundary", new_callable=AsyncMock), \
+         patch.object(sut, "_check_market_open_reset", new_callable=AsyncMock), \
+         patch.object(sut, "_get_overview", new_callable=AsyncMock, return_value={}) as mock_ov, \
+         patch.object(sut, "_get_short_interest", new_callable=AsyncMock, return_value={}) as mock_si, \
+         patch.object(sut, "_get_short_volume", new_callable=AsyncMock, return_value={}) as mock_sv, \
+         patch.object(sut, "_get_splits", new_callable=AsyncMock, return_value=[]) as mock_sp:
+        await sut.analyze_data(data)
+
+    # Assert — all enrichment methods called with correct symbol
+    mock_ov.assert_awaited_once_with("TSLA")
+    mock_si.assert_awaited_once_with("TSLA")
+    mock_sv.assert_awaited_once_with("TSLA")
+    mock_sp.assert_awaited_once_with("TSLA")


### PR DESCRIPTION
## Summary

Implements `EnhancedQuoteAnalyzer` — the first production use case for the Market Data Scanner (MDS). Subscribes to `quote:*` pub/sub, maintains session-aware HOD/LOD in memory, enriches with company/short interest data via a three-tier cache, and publishes `enhanced_quote:{symbol}` to WDC.

## Changes

- `src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py` — new analyzer
- `src/kuhl_haus/mdp/enum/widget_data_cache_keys.py` — add `ENHANCED_QUOTE`
- `src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py` — add `ENHANCED_QUOTE = SEVEN_DAYS`
- `tests/analyzers/test_enhanced_quote_analyzer.py` — 65 tests, all passing

## Architecture

```
quote:* (WDC pub/sub)
  └── EnhancedQuoteAnalyzer
        ├── session H/L (6 in-memory dicts, reset at 4AM/9:30AM ET)
        ├── three-tier enrichment cache (memory → WDC Redis → Massive API)
        └── enhanced_quote:{symbol} (WDC, 7-day TTL)
```

## Session tracking

Three sessions tracked independently: pre-market (4:00–9:30 AM ET), regular (9:30 AM–4:00 PM ET), after-hours (4:00–8:00 PM ET). Session detected from `start_timestamp` on each incoming quote event.

## Enrichment cache

| Data | Source | Redis TTL |
|------|--------|-----------|
| Ticker overview (name, description, exchange, etc.) | Massive `/v3/reference/tickers` | 30 days |
| Short interest + days to cover | Massive `/v3/reference/stocks/short_interest` | 14 days |
| Short volume ratio | Massive `/v3/reference/stocks/short_volume` | 24h |
| Splits | Massive `/v3/reference/splits` | 24h |

MDC is never touched — WDC only.

## Testing

65 tests covering session detection, H/L update logic, day/market-open resets, all three cache tiers, full payload structure, None-safety, and boundary check calls.

refs #82