### PR TITLE
fix: self-healing enrichment cache — short retry TTL on API failure

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
@@ -31,6 +31,7 @@ _OVERVIEW_TTL = 30 * 86400       # 30 days — effectively static reference data
 _SHORT_INTEREST_TTL = 14 * 86400  # 14 days — bi-monthly publication cadence
 _SHORT_VOLUME_TTL = 86400         # 24 hours — daily short volume data
 _SPLITS_TTL = 86400               # 24 hours — splits are infrequent but daily cache is safe
+_ENRICHMENT_RETRY_TTL = 60        # 60 seconds — short retry TTL on API failure (self-healing)
 
 
 class EnhancedQuoteAnalyzer(Analyzer):
@@ -319,11 +320,13 @@ class EnhancedQuoteAnalyzer(Analyzer):
                         r, "share_class_shares_outstanding", None
                     ),
                 }
+            self._overview_cache[symbol] = data
+            await self.redis_client.setex(redis_key, _OVERVIEW_TTL, json.dumps(data))
         except Exception as e:
             self.logger.error(f"Error fetching overview for {symbol}: {e}")
-
-        self._overview_cache[symbol] = data
-        await self.redis_client.setex(redis_key, _OVERVIEW_TTL, json.dumps(data))
+            # Use short retry TTL — do NOT populate memory cache so the next
+            # call retries Redis (and then the API) after 60 seconds.
+            await self.redis_client.setex(redis_key, _ENRICHMENT_RETRY_TTL, json.dumps({}))
         return data
 
     @tracer.start_as_current_span("eqa._get_short_interest")
@@ -357,11 +360,11 @@ class EnhancedQuoteAnalyzer(Analyzer):
                     "short_interest": getattr(item, "short_interest", None),
                     "days_to_cover": getattr(item, "days_to_cover", None),
                 }
+            self._short_interest_cache[symbol] = data
+            await self.redis_client.setex(redis_key, _SHORT_INTEREST_TTL, json.dumps(data))
         except Exception as e:
             self.logger.error(f"Error fetching short interest for {symbol}: {e}")
-
-        self._short_interest_cache[symbol] = data
-        await self.redis_client.setex(redis_key, _SHORT_INTEREST_TTL, json.dumps(data))
+            await self.redis_client.setex(redis_key, _ENRICHMENT_RETRY_TTL, json.dumps({}))
         return data
 
     @tracer.start_as_current_span("eqa._get_short_volume")
@@ -394,11 +397,11 @@ class EnhancedQuoteAnalyzer(Analyzer):
                 data = {
                     "short_volume_ratio": getattr(item, "short_volume_ratio", None),
                 }
+            self._short_volume_cache[symbol] = data
+            await self.redis_client.setex(redis_key, _SHORT_VOLUME_TTL, json.dumps(data))
         except Exception as e:
             self.logger.error(f"Error fetching short volume for {symbol}: {e}")
-
-        self._short_volume_cache[symbol] = data
-        await self.redis_client.setex(redis_key, _SHORT_VOLUME_TTL, json.dumps(data))
+            await self.redis_client.setex(redis_key, _ENRICHMENT_RETRY_TTL, json.dumps({}))
         return data
 
     @tracer.start_as_current_span("eqa._get_splits")
@@ -433,9 +436,9 @@ class EnhancedQuoteAnalyzer(Analyzer):
                     "split_to": getattr(item, "split_to", None),
                     "ticker": getattr(item, "ticker", None),
                 })
+            self._splits_cache[symbol] = data
+            await self.redis_client.setex(redis_key, _SPLITS_TTL, json.dumps(data))
         except Exception as e:
             self.logger.error(f"Error fetching splits for {symbol}: {e}")
-
-        self._splits_cache[symbol] = data
-        await self.redis_client.setex(redis_key, _SPLITS_TTL, json.dumps(data))
+            await self.redis_client.setex(redis_key, _ENRICHMENT_RETRY_TTL, json.dumps([]))
         return data

--- a/tests/analyzers/test_enhanced_quote_analyzer.py
+++ b/tests/analyzers/test_enhanced_quote_analyzer.py
@@ -1186,3 +1186,121 @@ async def test_eqa_analyze_data_enrichment_calls_use_correct_symbol(sut):
     mock_si.assert_awaited_once_with("TSLA")
     mock_sv.assert_awaited_once_with("TSLA")
     mock_sp.assert_awaited_once_with("TSLA")
+
+
+# ---------------------------------------------------------------------------
+# Bug #85: Enrichment cache poison — short retry TTL on failure
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_with_api_error_expect_short_retry_ttl(sut, mock_redis):
+    """On API failure, Redis TTL must be short (retry), not full 30-day TTL."""
+    # Arrange
+    sut.rest_client.get_ticker_details.side_effect = Exception("boom")
+
+    # Act
+    await sut._get_overview("FAIL")
+
+    # Assert — setex called with short TTL
+    call_args = mock_redis.setex.call_args
+    key, ttl, value = call_args[0]
+    assert ttl <= 120, f"Expected short retry TTL ≤120s on failure, got {ttl}s"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_with_api_error_expect_no_memory_cache_population(sut):
+    """On API failure, symbol must NOT be stored in the in-memory cache."""
+    # Arrange
+    sut.rest_client.get_ticker_details.side_effect = Exception("boom")
+
+    # Act
+    await sut._get_overview("FAIL")
+
+    # Assert
+    assert "FAIL" not in sut._overview_cache
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_interest_with_api_error_expect_short_retry_ttl(sut, mock_redis):
+    """On API failure, short interest Redis TTL must be short (retry)."""
+    # Arrange
+    sut.rest_client.list_short_interest.side_effect = Exception("boom")
+
+    # Act
+    await sut._get_short_interest("FAIL")
+
+    # Assert
+    call_args = mock_redis.setex.call_args
+    key, ttl, value = call_args[0]
+    assert ttl <= 120, f"Expected short retry TTL ≤120s on failure, got {ttl}s"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_interest_with_api_error_expect_no_memory_cache(sut):
+    """On API failure, symbol must NOT be stored in short interest memory cache."""
+    # Arrange
+    sut.rest_client.list_short_interest.side_effect = Exception("boom")
+
+    # Act
+    await sut._get_short_interest("FAIL")
+
+    # Assert
+    assert "FAIL" not in sut._short_interest_cache
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_volume_with_api_error_expect_short_retry_ttl(sut, mock_redis):
+    """On API failure, short volume Redis TTL must be short (retry)."""
+    # Arrange
+    sut.rest_client.list_short_volume.side_effect = Exception("boom")
+
+    # Act
+    await sut._get_short_volume("FAIL")
+
+    # Assert
+    call_args = mock_redis.setex.call_args
+    key, ttl, value = call_args[0]
+    assert ttl <= 120, f"Expected short retry TTL ≤120s on failure, got {ttl}s"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_splits_with_api_error_expect_short_retry_ttl(sut, mock_redis):
+    """On API failure, splits Redis TTL must be short (retry)."""
+    # Arrange
+    sut.rest_client.list_splits.side_effect = Exception("boom")
+
+    # Act
+    await sut._get_splits("FAIL")
+
+    # Assert
+    call_args = mock_redis.setex.call_args
+    key, ttl, value = call_args[0]
+    assert ttl <= 120, f"Expected short retry TTL ≤120s on failure, got {ttl}s"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_with_none_rest_client_expect_no_memory_cache(sut):
+    """When rest_client is None, symbol must NOT be stored in memory cache."""
+    # Arrange
+    sut.rest_client = None
+
+    # Act
+    await sut._get_overview("FAIL")
+
+    # Assert
+    assert "FAIL" not in sut._overview_cache
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_with_none_rest_client_expect_short_retry_ttl(sut, mock_redis):
+    """When rest_client is None, Redis TTL must be short (retry)."""
+    # Arrange
+    sut.rest_client = None
+
+    # Act
+    await sut._get_overview("FAIL")
+
+    # Assert
+    call_args = mock_redis.setex.call_args
+    key, ttl, value = call_args[0]
+    assert ttl <= 120, f"Expected short retry TTL ≤120s when rest_client is None, got {ttl}s"


### PR DESCRIPTION
## Bug
On API failure (e.g. missing `MASSIVE_API_KEY`), all four enrichment methods cached empty results with their full TTL (up to 30 days). After fixing the API key, the pod would never re-fetch — the poison cache blocked retries until TTL expiry.

## Fix

Added `_ENRICHMENT_RETRY_TTL = 60s`. On exception in any enrichment method:
- Write empty sentinel to Redis with **60s retry TTL** (not 30d/14d/24h)
- **Do NOT** populate in-memory cache — so next call hits Redis, gets a miss after 60s, and retries the API

Pod self-heals within 60 seconds of the API key being fixed. No manual cache flush needed.

## Cache flush for poisoned deployments
If currently poisoned, flush before deploying:
```bash
kubectl port-forward svc/wdc-redis -n crow 6381:6379 &
redis-cli -p 6381 --scan --pattern 'enrichment:*' | xargs redis-cli -p 6381 del
```

refs #85