### PR TITLE
fix: do not trap Redis empty sentinel in memory cache

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
@@ -299,7 +299,8 @@ class EnhancedQuoteAnalyzer(Analyzer):
         cached = await self.redis_client.get(redis_key)
         if cached:
             data = json.loads(cached)
-            self._overview_cache[symbol] = data
+            if data:  # Empty sentinel — do NOT trap in memory (would block API retries after TTL)
+                self._overview_cache[symbol] = data
             return data
 
         data = {}
@@ -348,7 +349,8 @@ class EnhancedQuoteAnalyzer(Analyzer):
         cached = await self.redis_client.get(redis_key)
         if cached:
             data = json.loads(cached)
-            self._short_interest_cache[symbol] = data
+            if data:
+                self._short_interest_cache[symbol] = data
             return data
 
         data = {}
@@ -386,7 +388,8 @@ class EnhancedQuoteAnalyzer(Analyzer):
         cached = await self.redis_client.get(redis_key)
         if cached:
             data = json.loads(cached)
-            self._short_volume_cache[symbol] = data
+            if data:
+                self._short_volume_cache[symbol] = data
             return data
 
         data = {}
@@ -423,7 +426,8 @@ class EnhancedQuoteAnalyzer(Analyzer):
         cached = await self.redis_client.get(redis_key)
         if cached:
             data = json.loads(cached)
-            self._splits_cache[symbol] = data
+            if data:  # Empty sentinel — do NOT trap in memory
+                self._splits_cache[symbol] = data
             return data
 
         data = []

--- a/tests/analyzers/test_enhanced_quote_analyzer.py
+++ b/tests/analyzers/test_enhanced_quote_analyzer.py
@@ -1304,3 +1304,79 @@ async def test_eqa_get_overview_with_none_rest_client_expect_short_retry_ttl(sut
     call_args = mock_redis.setex.call_args
     key, ttl, value = call_args[0]
     assert ttl <= 120, f"Expected short retry TTL ≤120s when rest_client is None, got {ttl}s"
+
+
+# ---------------------------------------------------------------------------
+# Bug #85 part 2: Redis sentinel {} must NOT be trapped in memory cache
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_with_redis_empty_sentinel_expect_no_memory_cache(sut, mock_redis):
+    """When Redis has an empty sentinel {}, must NOT populate memory cache.
+
+    If {} is stored in memory, the symbol is permanently blocked from retrying
+    the API even after the Redis TTL expires.
+    """
+    # Arrange — Redis returns empty sentinel (written on a previous API failure)
+    mock_redis.get.return_value = json.dumps({})
+
+    # Act
+    result = await sut._get_overview("JPM")
+
+    # Assert — memory cache must NOT contain JPM (would block future retries)
+    assert "JPM" not in sut._overview_cache
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_interest_with_redis_empty_sentinel_expect_no_memory_cache(sut, mock_redis):
+    """When Redis has an empty sentinel {}, must NOT populate short interest memory cache."""
+    mock_redis.get.return_value = json.dumps({})
+    result = await sut._get_short_interest("JPM")
+    assert "JPM" not in sut._short_interest_cache
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_volume_with_redis_empty_sentinel_expect_no_memory_cache(sut, mock_redis):
+    """When Redis has an empty sentinel {}, must NOT populate short volume memory cache."""
+    mock_redis.get.return_value = json.dumps({})
+    result = await sut._get_short_volume("JPM")
+    assert "JPM" not in sut._short_volume_cache
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_splits_with_redis_empty_sentinel_expect_no_memory_cache(sut, mock_redis):
+    """When Redis has an empty sentinel [], must NOT populate splits memory cache."""
+    mock_redis.get.return_value = json.dumps([])
+    result = await sut._get_splits("JPM")
+    assert "JPM" not in sut._splits_cache
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_after_redis_sentinel_expires_expect_api_retry(sut, mock_redis):
+    """After Redis sentinel expires (miss), must retry the API and populate memory on success."""
+    # Arrange — first call: Redis miss (sentinel expired), API succeeds
+    mock_redis.get.return_value = None
+    overview_result = MagicMock()
+    overview_result.results = MagicMock()
+    overview_result.results.name = "JPMorgan Chase"
+    overview_result.results.description = "A bank."
+    overview_result.results.homepage_url = "https://jpmorganchase.com"
+    overview_result.results.list_date = "1969-03-05"
+    overview_result.results.market_cap = 500000000000.0
+    overview_result.results.primary_exchange = "XNYS"
+    overview_result.results.sic_description = "State commercial banks"
+    overview_result.results.total_employees = 300000
+    overview_result.results.share_class_shares_outstanding = 2900000000
+    sut.rest_client.get_ticker_details.return_value = overview_result
+
+    # Act
+    result = await sut._get_overview("JPM")
+
+    # Assert — memory cache populated, real data returned
+    assert "JPM" in sut._overview_cache
+    assert sut._overview_cache["JPM"]["name"] == "JPMorgan Chase"
+    assert result["name"] == "JPMorgan Chase"


### PR DESCRIPTION
## Bug

After PR #86 (short retry TTL), a second bug remained: when the Redis hit path returned an empty sentinel `{}`, it unconditionally populated the in-memory cache with `{}`. After the 60s Redis TTL expired, the memory hit blocked any API retry permanently.

**Failure chain with only PR #86:**
1. API fails → Redis gets `{}` with 60s TTL, memory untouched ✅
2. Next call hits Redis → returns `{}}` → **stores `{}` in memory** ← the trap
3. 60s later Redis expires → memory hit with `{}` → never retries API ❌

## Fix

Added `if data:` guard on all four Redis hit paths. Empty sentinels are served from Redis during the retry window but never stored in memory. After TTL expiry: memory miss → Redis miss → API retried → real data cached on success.

## Tests

5 new tests (76 total):
- Empty sentinel from Redis does NOT populate memory cache (all 4 methods)
- After sentinel expires, API is retried and memory is populated on success

refs #85