### PR TITLE
fix: run all blocking REST calls in executor to prevent event loop blockage

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
@@ -8,6 +8,8 @@ short interest, short volume, splits) fetched via a three-tier cache
 Session detection uses the Massive ``get_market_status()`` API (60-second
 in-memory cache) so exchange holidays and early closes are handled correctly.
 """
+import asyncio
+import functools
 import json
 import logging
 import time
@@ -151,7 +153,10 @@ class EnhancedQuoteAnalyzer(Analyzer):
         if now - self._market_status_fetched_at < 60:
             return self._market_status
         try:
-            self._market_status = self.rest_client.get_market_status()
+            loop = asyncio.get_event_loop()
+            self._market_status = await loop.run_in_executor(
+                None, self.rest_client.get_market_status
+            )
             self._market_status_fetched_at = now
         except Exception as e:
             self.logger.warning(f"get_market_status() failed: {e}")
@@ -305,7 +310,10 @@ class EnhancedQuoteAnalyzer(Analyzer):
 
         data = {}
         try:
-            response = self.rest_client.get_ticker_details(symbol)
+            loop = asyncio.get_event_loop()
+            response = await loop.run_in_executor(
+                None, functools.partial(self.rest_client.get_ticker_details, symbol)
+            )
             if response and getattr(response, "results", None):
                 r = response.results
                 data = {
@@ -355,7 +363,11 @@ class EnhancedQuoteAnalyzer(Analyzer):
 
         data = {}
         try:
-            items = list(self.rest_client.list_short_interest(ticker=symbol, limit=1))
+            loop = asyncio.get_event_loop()
+            items = await loop.run_in_executor(
+                None, functools.partial(self.rest_client.list_short_interest, ticker=symbol, limit=1)
+            )
+            items = list(items)
             if items:
                 item = items[0]
                 data = {
@@ -394,7 +406,11 @@ class EnhancedQuoteAnalyzer(Analyzer):
 
         data = {}
         try:
-            items = list(self.rest_client.list_short_volume(ticker=symbol, limit=1, order="desc"))
+            loop = asyncio.get_event_loop()
+            items = await loop.run_in_executor(
+                None, functools.partial(self.rest_client.list_short_volume, ticker=symbol, limit=1, order="desc")
+            )
+            items = list(items)
             if items:
                 item = items[0]
                 data = {
@@ -432,7 +448,11 @@ class EnhancedQuoteAnalyzer(Analyzer):
 
         data = []
         try:
-            items = list(self.rest_client.list_splits(ticker=symbol, limit=10))
+            loop = asyncio.get_event_loop()
+            items = await loop.run_in_executor(
+                None, functools.partial(self.rest_client.list_splits, ticker=symbol, limit=10)
+            )
+            items = list(items)
             for item in items:
                 data.append({
                     "execution_date": getattr(item, "execution_date", None),

--- a/tests/analyzers/test_enhanced_quote_analyzer.py
+++ b/tests/analyzers/test_enhanced_quote_analyzer.py
@@ -1,4 +1,5 @@
 """Tests for EnhancedQuoteAnalyzer — session HOD/LOD tracking and MDS enrichment."""
+import asyncio
 import json
 import time
 import pytest
@@ -1380,3 +1381,103 @@ async def test_eqa_get_overview_after_redis_sentinel_expires_expect_api_retry(su
     assert "JPM" in sut._overview_cache
     assert sut._overview_cache["JPM"]["name"] == "JPMorgan Chase"
     assert result["name"] == "JPMorgan Chase"
+
+
+# ---------------------------------------------------------------------------
+# run_in_executor — blocking REST calls must not block the event loop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_eqa_get_market_status_uses_run_in_executor(sut):
+    """get_market_status() must call rest_client via run_in_executor, not directly."""
+    # Arrange
+    loop = asyncio.get_event_loop()
+    executor_calls = []
+
+    original_run = loop.run_in_executor
+    async def mock_run_in_executor(executor, func, *args):
+        executor_calls.append(func)
+        return func(*args)
+
+    with patch.object(loop, 'run_in_executor', side_effect=mock_run_in_executor):
+        # Act
+        sut._market_status_fetched_at = 0  # force cache miss
+        await sut._get_market_status()
+
+    # Assert — get_market_status must have gone through run_in_executor
+    assert any(
+        getattr(f, '__self__', None) is sut.rest_client or 'get_market_status' in str(f)
+        for f in executor_calls
+    ), "get_market_status() must be called via run_in_executor"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_api_call_uses_run_in_executor(sut, mock_redis):
+    """get_ticker_details() must be called via run_in_executor."""
+    mock_redis.get.return_value = None
+    loop = asyncio.get_event_loop()
+    executor_calls = []
+
+    original_run = loop.run_in_executor
+    async def mock_run_in_executor(executor, func, *args):
+        executor_calls.append(func)
+        return func(*args)
+
+    with patch.object(loop, 'run_in_executor', side_effect=mock_run_in_executor):
+        await sut._get_overview("AAPL")
+
+    assert any(
+        'get_ticker_details' in str(f) or getattr(f, '__func__', None) is type(sut.rest_client).get_ticker_details
+        for f in executor_calls
+    ), "get_ticker_details() must be called via run_in_executor"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_interest_api_call_uses_run_in_executor(sut, mock_redis):
+    """list_short_interest() must be called via run_in_executor."""
+    mock_redis.get.return_value = None
+    loop = asyncio.get_event_loop()
+    executor_calls = []
+
+    async def mock_run_in_executor(executor, func, *args):
+        executor_calls.append(func)
+        return func(*args)
+
+    with patch.object(loop, 'run_in_executor', side_effect=mock_run_in_executor):
+        await sut._get_short_interest("AAPL")
+
+    assert len(executor_calls) > 0, "list_short_interest() must be called via run_in_executor"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_short_volume_api_call_uses_run_in_executor(sut, mock_redis):
+    """list_short_volume() must be called via run_in_executor."""
+    mock_redis.get.return_value = None
+    loop = asyncio.get_event_loop()
+    executor_calls = []
+
+    async def mock_run_in_executor(executor, func, *args):
+        executor_calls.append(func)
+        return func(*args)
+
+    with patch.object(loop, 'run_in_executor', side_effect=mock_run_in_executor):
+        await sut._get_short_volume("AAPL")
+
+    assert len(executor_calls) > 0, "list_short_volume() must be called via run_in_executor"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_splits_api_call_uses_run_in_executor(sut, mock_redis):
+    """list_splits() must be called via run_in_executor."""
+    mock_redis.get.return_value = None
+    loop = asyncio.get_event_loop()
+    executor_calls = []
+
+    async def mock_run_in_executor(executor, func, *args):
+        executor_calls.append(func)
+        return func(*args)
+
+    with patch.object(loop, 'run_in_executor', side_effect=mock_run_in_executor):
+        await sut._get_splits("AAPL")
+
+    assert len(executor_calls) > 0, "list_splits() must be called via run_in_executor"


### PR DESCRIPTION
## Bug

All five Massive REST client calls in `EnhancedQuoteAnalyzer` were synchronous blocking calls made directly inside `async` methods. This blocks the entire asyncio event loop while the HTTP request executes, starving all other coroutines — including the FastAPI health check endpoint, which would hang indefinitely.

## Fix

All blocking calls wrapped with `asyncio.get_event_loop().run_in_executor(None, ...)`:
- `get_market_status()` in `_get_market_status`
- `get_ticker_details()` in `_get_overview`
- `list_short_interest()` in `_get_short_interest`
- `list_short_volume()` in `_get_short_volume`
- `list_splits()` in `_get_splits`

## Tests

5 new tests (81 total) asserting each REST call goes through `run_in_executor`.

refs #85