### PR TITLE
fix: use next()/islice() instead of list() to prevent SDK auto-pagination

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
@@ -10,6 +10,7 @@ in-memory cache) so exchange holidays and early closes are handled correctly.
 """
 import asyncio
 import functools
+import itertools
 import json
 import logging
 import time
@@ -153,7 +154,7 @@ class EnhancedQuoteAnalyzer(Analyzer):
         if now - self._market_status_fetched_at < 60:
             return self._market_status
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             self._market_status = await loop.run_in_executor(
                 None, self.rest_client.get_market_status
             )
@@ -310,7 +311,7 @@ class EnhancedQuoteAnalyzer(Analyzer):
 
         data = {}
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             response = await loop.run_in_executor(
                 None, functools.partial(self.rest_client.get_ticker_details, symbol)
             )
@@ -363,13 +364,17 @@ class EnhancedQuoteAnalyzer(Analyzer):
 
         data = {}
         try:
-            loop = asyncio.get_event_loop()
-            items = await loop.run_in_executor(
-                None, functools.partial(self.rest_client.list_short_interest, ticker=symbol, limit=1)
+            loop = asyncio.get_running_loop()
+            # Use next() — fetches exactly one page (limit=1), no pagination triggered
+            # Sort desc to get most recent settlement date first
+            iterator = await loop.run_in_executor(
+                None, functools.partial(
+                    self.rest_client.list_short_interest,
+                    ticker=symbol, limit=1, sort="settlement_date.desc"
+                )
             )
-            items = list(items)
-            if items:
-                item = items[0]
+            item = next(iterator, None)
+            if item is not None:
                 data = {
                     "short_interest": getattr(item, "short_interest", None),
                     "days_to_cover": getattr(item, "days_to_cover", None),
@@ -406,13 +411,17 @@ class EnhancedQuoteAnalyzer(Analyzer):
 
         data = {}
         try:
-            loop = asyncio.get_event_loop()
-            items = await loop.run_in_executor(
-                None, functools.partial(self.rest_client.list_short_volume, ticker=symbol, limit=1, order="desc")
+            loop = asyncio.get_running_loop()
+            # Use next() — fetches exactly one page (limit=1), no pagination triggered
+            # Sort desc to get most recent date first
+            iterator = await loop.run_in_executor(
+                None, functools.partial(
+                    self.rest_client.list_short_volume,
+                    ticker=symbol, limit=1, sort="date.desc"
+                )
             )
-            items = list(items)
-            if items:
-                item = items[0]
+            item = next(iterator, None)
+            if item is not None:
                 data = {
                     "short_volume_ratio": getattr(item, "short_volume_ratio", None),
                 }
@@ -448,12 +457,13 @@ class EnhancedQuoteAnalyzer(Analyzer):
 
         data = []
         try:
-            loop = asyncio.get_event_loop()
-            items = await loop.run_in_executor(
+            loop = asyncio.get_running_loop()
+            # islice caps at 10 items from the first page — no pagination triggered
+            # Default sort is execution_date.desc so most recent splits come first
+            iterator = await loop.run_in_executor(
                 None, functools.partial(self.rest_client.list_splits, ticker=symbol, limit=10)
             )
-            items = list(items)
-            for item in items:
+            for item in itertools.islice(iterator, 10):
                 data.append({
                     "execution_date": getattr(item, "execution_date", None),
                     "split_from": getattr(item, "split_from", None),

--- a/tests/analyzers/test_enhanced_quote_analyzer.py
+++ b/tests/analyzers/test_enhanced_quote_analyzer.py
@@ -1391,7 +1391,7 @@ async def test_eqa_get_overview_after_redis_sentinel_expires_expect_api_retry(su
 async def test_eqa_get_market_status_uses_run_in_executor(sut):
     """get_market_status() must call rest_client via run_in_executor, not directly."""
     # Arrange
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     executor_calls = []
 
     original_run = loop.run_in_executor
@@ -1415,7 +1415,7 @@ async def test_eqa_get_market_status_uses_run_in_executor(sut):
 async def test_eqa_get_overview_api_call_uses_run_in_executor(sut, mock_redis):
     """get_ticker_details() must be called via run_in_executor."""
     mock_redis.get.return_value = None
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     executor_calls = []
 
     original_run = loop.run_in_executor
@@ -1436,7 +1436,7 @@ async def test_eqa_get_overview_api_call_uses_run_in_executor(sut, mock_redis):
 async def test_eqa_get_short_interest_api_call_uses_run_in_executor(sut, mock_redis):
     """list_short_interest() must be called via run_in_executor."""
     mock_redis.get.return_value = None
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     executor_calls = []
 
     async def mock_run_in_executor(executor, func, *args):
@@ -1453,7 +1453,7 @@ async def test_eqa_get_short_interest_api_call_uses_run_in_executor(sut, mock_re
 async def test_eqa_get_short_volume_api_call_uses_run_in_executor(sut, mock_redis):
     """list_short_volume() must be called via run_in_executor."""
     mock_redis.get.return_value = None
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     executor_calls = []
 
     async def mock_run_in_executor(executor, func, *args):
@@ -1470,7 +1470,7 @@ async def test_eqa_get_short_volume_api_call_uses_run_in_executor(sut, mock_redi
 async def test_eqa_get_splits_api_call_uses_run_in_executor(sut, mock_redis):
     """list_splits() must be called via run_in_executor."""
     mock_redis.get.return_value = None
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     executor_calls = []
 
     async def mock_run_in_executor(executor, func, *args):


### PR DESCRIPTION
## Bug

`list()` on the Massive SDK's `list_*` iterators triggers unbounded auto-pagination — the SDK follows `next_url` until exhausted, fetching thousands of records. Massive resets the connection after enough requests, causing a retry loop.

## Fix

- `list_short_interest`: `next(iterator, None)` — one HTTP call, one result. Added `sort='settlement_date.desc'` to get most recent entry.
- `list_short_volume`: `next(iterator, None)` — one HTTP call, one result. Added `sort='date.desc'` to get most recent entry.
- `list_splits`: `itertools.islice(iterator, 10)` — one HTTP call, up to 10 results, no `next_url` follow. Default sort is `execution_date.desc`.

refs #85