### PR TITLE
fix: do not memory-cache empty API responses in enrichment lookups

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/enhanced_quote_analyzer.py
@@ -310,6 +310,7 @@ class EnhancedQuoteAnalyzer(Analyzer):
             Dict with overview fields, or empty dict on error/no data.
         """
         if symbol in self._overview_cache:
+            self.logger.debug(f"[overview:{symbol}] memory cache hit")
             return self._overview_cache[symbol]
 
         redis_key = f"enrichment:overview:{symbol}"
@@ -317,16 +318,22 @@ class EnhancedQuoteAnalyzer(Analyzer):
         if cached:
             data = json.loads(cached)
             if data:  # Empty sentinel — do NOT trap in memory (would block API retries after TTL)
+                self.logger.debug(f"[overview:{symbol}] redis cache hit — populating memory")
                 self._overview_cache[symbol] = data
+            else:
+                self.logger.debug(f"[overview:{symbol}] redis empty sentinel — will retry after TTL")
             return data
 
         data = {}
         try:
+            self.logger.debug(f"[overview:{symbol}] cache miss — calling API")
             loop = asyncio.get_running_loop()
             response = await loop.run_in_executor(
                 None, functools.partial(self.rest_client.get_ticker_details, symbol)
             )
-            if response and getattr(response, "results", None):
+            has_results = response and getattr(response, "results", None)
+            self.logger.debug(f"[overview:{symbol}] API response received — has_results={bool(has_results)}")
+            if has_results:
                 r = response.results
                 data = {
                     "name": getattr(r, "name", None),
@@ -341,10 +348,17 @@ class EnhancedQuoteAnalyzer(Analyzer):
                         r, "share_class_shares_outstanding", None
                     ),
                 }
-            self._overview_cache[symbol] = data
-            await self.redis_client.setex(redis_key, _OVERVIEW_TTL, json.dumps(data))
+            if data:
+                # Only cache in memory + use long TTL when we have real data
+                self.logger.debug(f"[overview:{symbol}] caching in memory + Redis (TTL={_OVERVIEW_TTL}s) — name={data.get('name')!r}")
+                self._overview_cache[symbol] = data
+                await self.redis_client.setex(redis_key, _OVERVIEW_TTL, json.dumps(data))
+            else:
+                # API returned no results — short retry TTL, skip memory cache
+                self.logger.warning(f"[overview:{symbol}] API returned no results — writing retry sentinel (TTL={_ENRICHMENT_RETRY_TTL}s)")
+                await self.redis_client.setex(redis_key, _ENRICHMENT_RETRY_TTL, json.dumps({}))
         except Exception as e:
-            self.logger.error(f"Error fetching overview for {symbol}: {e}")
+            self.logger.error(f"[overview:{symbol}] API call failed: {e}")
             # Use short retry TTL — do NOT populate memory cache so the next
             # call retries Redis (and then the API) after 60 seconds.
             await self.redis_client.setex(redis_key, _ENRICHMENT_RETRY_TTL, json.dumps({}))
@@ -481,8 +495,13 @@ class EnhancedQuoteAnalyzer(Analyzer):
                     "split_to": getattr(item, "split_to", None),
                     "ticker": getattr(item, "ticker", None),
                 })
-            self._splits_cache[symbol] = data
-            await self.redis_client.setex(redis_key, _SPLITS_TTL, json.dumps(data))
+            if data:
+                # Only cache in memory + use long TTL when we have real data
+                self._splits_cache[symbol] = data
+                await self.redis_client.setex(redis_key, _SPLITS_TTL, json.dumps(data))
+            else:
+                # No splits found — short retry TTL, skip memory cache
+                await self.redis_client.setex(redis_key, _ENRICHMENT_RETRY_TTL, json.dumps([]))
         except Exception as e:
             self.logger.error(f"Error fetching splits for {symbol}: {e}")
             await self.redis_client.setex(redis_key, _ENRICHMENT_RETRY_TTL, json.dumps([]))

--- a/tests/analyzers/test_enhanced_quote_analyzer.py
+++ b/tests/analyzers/test_enhanced_quote_analyzer.py
@@ -9,7 +9,7 @@ from zoneinfo import ZoneInfo
 
 from massive.rest.models import MarketStatus
 
-from kuhl_haus.mdp.analyzers.enhanced_quote_analyzer import EnhancedQuoteAnalyzer
+from kuhl_haus.mdp.analyzers.enhanced_quote_analyzer import EnhancedQuoteAnalyzer, _ENRICHMENT_RETRY_TTL
 from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
 from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
 from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
@@ -1503,3 +1503,56 @@ async def test_eqa_get_splits_api_call_uses_run_in_executor(sut, mock_redis):
         await sut._get_splits("AAPL")
 
     assert len(executor_calls) > 0, "list_splits() must be called via run_in_executor"
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_overview_with_empty_api_response_expect_retry_ttl_not_memory_cached(
+    sut, mock_redis, mock_rest_client
+):
+    """When API returns a response with no results, must use retry TTL and NOT cache in memory.
+
+    This is the 'API succeeded but returned nothing' bug — previously the code would
+    write {} to memory cache permanently, blocking all future retries.
+    """
+    # Arrange — Redis miss, API returns response with no results
+    mock_redis.get.return_value = None
+    mock_rest_client.get_ticker_details.return_value.results = None
+
+    # Act
+    result = await sut._get_overview("ZNTL")
+
+    # Assert — empty result, NOT in memory, Redis written with short retry TTL
+    assert result == {}
+    assert "ZNTL" not in sut._overview_cache
+    mock_redis.setex.assert_called_once()
+    ttl_used = mock_redis.setex.call_args[0][1]
+    assert ttl_used == _ENRICHMENT_RETRY_TTL, (
+        f"Expected retry TTL {_ENRICHMENT_RETRY_TTL}, got {ttl_used} — "
+        "empty API response must use short TTL to allow retries"
+    )
+
+
+@pytest.mark.asyncio
+async def test_eqa_get_splits_with_empty_api_response_expect_retry_ttl_not_memory_cached(
+    sut, mock_redis, mock_rest_client
+):
+    """When splits API returns no results, must use retry TTL and NOT cache in memory.
+
+    Previously empty [] would be written to memory cache permanently.
+    """
+    # Arrange — Redis miss, API returns empty iterator
+    mock_redis.get.return_value = None
+    mock_rest_client.list_splits.return_value = iter([])
+
+    # Act
+    result = await sut._get_splits("ZNTL")
+
+    # Assert — empty result, NOT in memory, Redis written with short retry TTL
+    assert result == []
+    assert "ZNTL" not in sut._splits_cache
+    mock_redis.setex.assert_called_once()
+    ttl_used = mock_redis.setex.call_args[0][1]
+    assert ttl_used == _ENRICHMENT_RETRY_TTL, (
+        f"Expected retry TTL {_ENRICHMENT_RETRY_TTL}, got {ttl_used} — "
+        "empty splits response must use short TTL to allow retries"
+    )


### PR DESCRIPTION
## Bug

When `get_ticker_details()` or `list_splits()` returns a successful response but with no results, the code was treating it identically to a cache hit — writing `{}` / `[]` to the **in-memory cache permanently**. Since memory is checked first, the symbol was blocked from ever reaching Redis or the API again, for the lifetime of the process.

This is why all tickers showed null company data: first quote populates memory with `{}`, every subsequent quote returns `{}` from memory without calling the API.

## Fix

Apply the same `if data:` guard to the **write path** that already existed on the Redis read path:
- Real data → memory cache + long TTL in Redis
- Empty response → skip memory, write with `_ENRICHMENT_RETRY_TTL` (60s) in Redis

Consistent with the exception path behavior.

## Tests

Two new regression tests covering the empty-API-response path for overview and splits.

refs #85