### PR TITLE
feat: add DailyRangeAnalyzer — pure HOD/LOD tracker, no REST calls

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -1,0 +1,229 @@
+"""Daily range analyzer — session HOD/LOD tracking.
+
+Subscribes to the ``quote:*`` feed and publishes per-symbol session
+high/low (pre-market, regular, after-hours) to ``daily_range:{symbol}``.
+
+No external API calls are made. All state is maintained in process memory
+and coordinated via lightweight Redis keys for boundary resets.
+
+Session detection uses the Massive ``get_market_status()`` API (60-second
+in-memory cache) so exchange holidays and early closes are handled correctly.
+
+Boundary resets:
+- 4:00 AM ET: all six HOD/LOD dicts cleared (SET NX per-day guard on Redis)
+- 9:30 AM ET: pre-market HOD/LOD cleared (SET NX per-day guard on Redis)
+"""
+import asyncio
+import functools
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Optional, List
+from zoneinfo import ZoneInfo
+
+from massive.rest.models import MarketStatus
+
+from kuhl_haus.mdp.analyzers.analyzer import Analyzer, AnalyzerOptions
+from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
+from kuhl_haus.mdp.enum.market_status_value import MarketStatusValue
+from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
+from kuhl_haus.mdp.helpers.observability import get_tracer
+
+tracer = get_tracer(__name__)
+
+
+class DailyRangeAnalyzer(Analyzer):
+    """Tracks intraday session highs and lows for real-time quote events.
+
+    Maintains per-symbol high/low for three intraday sessions (pre-market,
+    regular, after-hours) in process memory. Publishes results to
+    ``daily_range:{symbol}`` in the WDC on every quote tick.
+
+    Concurrency: HOD/LOD state is per-instance (not coordinated across
+    replicas). Each instance maintains its own in-memory window.
+    """
+
+    DAY_BOUNDARY_KEY = "daily_range:day_boundary"
+    MARKET_OPEN_RESET_KEY = "daily_range:market_open_reset:{date}"
+
+    def __init__(self, options: AnalyzerOptions):
+        super().__init__(options)
+        self.logger = logging.getLogger(__name__)
+        self.redis_client = options.new_redis_client()
+        self.rest_client = options.new_rest_client()
+
+        # Session HOD/LOD — in-memory, per-instance
+        self._pre_market_high: dict = {}
+        self._pre_market_low: dict = {}
+        self._regular_session_high: dict = {}
+        self._regular_session_low: dict = {}
+        self._after_hours_high: dict = {}
+        self._after_hours_low: dict = {}
+
+        # Market status cache (60-second TTL)
+        self._market_status: Optional[MarketStatus] = None
+        self._market_status_fetched_at: float = 0.0  # monotonic epoch seconds
+
+    @tracer.start_as_current_span("dra.analyze_data")
+    async def analyze_data(self, data: dict) -> Optional[List[MarketDataAnalyzerResult]]:
+        """Process a quote event and publish session HOD/LOD results.
+
+        Args:
+            data: Quote event dict from the ``quote:*`` feed.
+
+        Returns:
+            List with a single ``MarketDataAnalyzerResult`` for the symbol,
+            or ``None`` if the event could not be processed.
+        """
+        symbol = data.get("sym") or data.get("symbol")
+        if not symbol:
+            return None
+
+        await self._check_day_boundary()
+        await self._check_market_open_reset()
+        await self._update_session_hod_lod(symbol, data)
+
+        payload = {
+            **data,
+            "pre_market_high": self._pre_market_high.get(symbol),
+            "pre_market_low": self._pre_market_low.get(symbol),
+            "regular_session_high": self._regular_session_high.get(symbol),
+            "regular_session_low": self._regular_session_low.get(symbol),
+            "after_hours_high": self._after_hours_high.get(symbol),
+            "after_hours_low": self._after_hours_low.get(symbol),
+        }
+
+        cache_key = f"{WidgetDataCacheKeys.DAILY_RANGE.value}:{symbol}"
+        return [MarketDataAnalyzerResult(
+            data=payload,
+            cache_key=cache_key,
+            cache_ttl=WidgetDataCacheTTL.DAILY_RANGE.value,
+            publish_key=cache_key,
+        )]
+
+    @tracer.start_as_current_span("dra._get_market_status")
+    async def _get_market_status(self) -> Optional[MarketStatus]:
+        """Fetch market status with 60-second in-memory cache.
+
+        Returns stale cache on API failure rather than None — better than
+        dropping events due to a transient error.
+        """
+        now = time.monotonic()
+        if self._market_status is not None and (now - self._market_status_fetched_at) < 60:
+            return self._market_status
+
+        try:
+            loop = asyncio.get_running_loop()
+            status = await loop.run_in_executor(None, self.rest_client.get_market_status)
+            self._market_status = status
+            self._market_status_fetched_at = now
+            return status
+        except Exception as e:
+            self.logger.warning(f"get_market_status() failed: {e}")
+            return self._market_status  # Return stale cache rather than None
+
+    @tracer.start_as_current_span("dra._get_session")
+    async def _get_session(self) -> Optional[str]:
+        """Return the current market session identifier.
+
+        Returns:
+            ``'pre_market'``, ``'regular'``, ``'after_hours'``, or ``None``
+            if the market is closed.
+        """
+        status = await self._get_market_status()
+        if status is None:
+            return None
+        market = getattr(status, "market", None)
+        if market == MarketStatusValue.OPEN.value:
+            return "regular"
+        early = getattr(status, "early_hours", False)
+        after = getattr(status, "after_hours", False)
+        if early:
+            return "pre_market"
+        if after:
+            return "after_hours"
+        return None
+
+    @tracer.start_as_current_span("dra._update_session_hod_lod")
+    async def _update_session_hod_lod(self, symbol: str, data: dict):
+        """Update session HOD/LOD for the given symbol.
+
+        Args:
+            symbol: Ticker symbol.
+            data: Quote event dict containing price fields.
+        """
+        session = await self._get_session()
+        if session is None:
+            return
+
+        high = data.get("high") or data.get("h")
+        low = data.get("low") or data.get("l")
+
+        if high is None or low is None:
+            return
+
+        if session == "pre_market":
+            high_dict, low_dict = self._pre_market_high, self._pre_market_low
+        elif session == "regular":
+            high_dict, low_dict = self._regular_session_high, self._regular_session_low
+        else:
+            high_dict, low_dict = self._after_hours_high, self._after_hours_low
+
+        current_high = high_dict.get(symbol)
+        current_low = low_dict.get(symbol)
+
+        if current_high is None or high > current_high:
+            high_dict[symbol] = high
+        if current_low is None or low < current_low:
+            low_dict[symbol] = low
+
+    @tracer.start_as_current_span("dra._check_day_boundary")
+    async def _check_day_boundary(self):
+        """Reset all HOD/LOD dicts at 4:00 AM ET (start of pre-market).
+
+        Uses a Redis SET NX key scoped to the current date to ensure the
+        reset fires exactly once per day per instance.
+        """
+        et = ZoneInfo("America/New_York")
+        now_et = datetime.now(tz=et)
+        if now_et.hour < 4:
+            return
+
+        today = now_et.strftime("%Y-%m-%d")
+        key = self.DAY_BOUNDARY_KEY
+        set_result = await self.redis_client.set(key, today, nx=True, ex=86400)
+        if set_result is None:
+            existing = await self.redis_client.get(key)
+            if existing and existing.decode() == today:
+                return
+
+        self.logger.info(f"Day boundary reset at {today}")
+        self._pre_market_high.clear()
+        self._pre_market_low.clear()
+        self._regular_session_high.clear()
+        self._regular_session_low.clear()
+        self._after_hours_high.clear()
+        self._after_hours_low.clear()
+
+    @tracer.start_as_current_span("dra._check_market_open_reset")
+    async def _check_market_open_reset(self):
+        """Clear pre-market HOD/LOD at 9:30 AM ET (regular session open).
+
+        Uses a Redis SET NX key scoped to the current date so the reset
+        fires exactly once per day per instance.
+        """
+        et = ZoneInfo("America/New_York")
+        now_et = datetime.now(tz=et)
+        if now_et.hour < 9 or (now_et.hour == 9 and now_et.minute < 30):
+            return
+
+        today = now_et.strftime("%Y-%m-%d")
+        key = self.MARKET_OPEN_RESET_KEY.format(date=today)
+        set_result = await self.redis_client.set(key, "1", nx=True, ex=86400)
+        if set_result is None:
+            return
+
+        self.logger.info(f"Market open reset for {today}")
+        self._pre_market_high.clear()
+        self._pre_market_low.clear()

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_keys.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_keys.py
@@ -66,4 +66,8 @@ class WidgetDataCacheKeys(Enum):
     NEWS_TICKER = 'news:ticker:{ticker}'
 
     # Enhanced quote feed
+    # @deprecated — replaced by DAILY_RANGE
     ENHANCED_QUOTE = 'enhanced_quote'  # Usage: f'{ENHANCED_QUOTE.value}:{symbol}'
+
+    # Daily range (HOD/LOD) feed — replaces ENHANCED_QUOTE
+    DAILY_RANGE = 'daily_range'  # Usage: f'{DAILY_RANGE.value}:{symbol}'

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
@@ -38,4 +38,8 @@ class WidgetDataCacheTTL(Enum):
     NEWS_TICKER = SEVEN_DAYS
 
     # Enhanced quote cache
+    # @deprecated — replaced by DAILY_RANGE
     ENHANCED_QUOTE = SEVEN_DAYS  # 7 days
+
+    # Daily range (HOD/LOD) cache — replaces ENHANCED_QUOTE
+    DAILY_RANGE = FOUR_DAYS  # 4 days — consistent with QUOTE TTL

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -1,0 +1,347 @@
+"""Tests for DailyRangeAnalyzer — session HOD/LOD tracking."""
+import asyncio
+import time
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
+
+from massive.rest.models import MarketStatus
+
+from kuhl_haus.mdp.analyzers.daily_range_analyzer import DailyRangeAnalyzer
+from kuhl_haus.mdp.analyzers.analyzer import AnalyzerOptions
+from kuhl_haus.mdp.data.market_data_analyzer_result import MarketDataAnalyzerResult
+from kuhl_haus.mdp.enum.widget_data_cache_keys import WidgetDataCacheKeys
+from kuhl_haus.mdp.enum.widget_data_cache_ttl import WidgetDataCacheTTL
+
+
+MODULE = "kuhl_haus.mdp.analyzers.daily_range_analyzer"
+
+ET = ZoneInfo("America/New_York")
+
+
+def _ms(year, month, day, hour, minute, tz=ET):
+    return int(datetime(year, month, day, hour, minute, 0, tzinfo=tz).timestamp() * 1000)
+
+
+PRE_MARKET_TS = _ms(2026, 4, 8, 5, 0)
+REGULAR_TS = _ms(2026, 4, 8, 10, 0)
+AFTER_HOURS_TS = _ms(2026, 4, 8, 17, 0)
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+@pytest.fixture
+def mock_redis():
+    redis = MagicMock()
+    redis.eval = AsyncMock(return_value=0)
+    # SET NX returns None when key already existed (no reset triggered).
+    # get() returns a bytes value matching today so the boundary guard exits early.
+    import datetime as _dt
+    _today = _dt.datetime.now(tz=ZoneInfo("America/New_York")).strftime("%Y-%m-%d").encode()
+    redis.set = AsyncMock(return_value=None)
+    redis.get = AsyncMock(return_value=_today)
+    redis.setex = AsyncMock()
+    return redis
+
+
+@pytest.fixture
+def mock_rest_client():
+    client = MagicMock()
+    client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    return client
+
+
+@pytest.fixture
+def mock_options(mock_redis, mock_rest_client):
+    opts = MagicMock(spec=AnalyzerOptions)
+    opts.new_redis_client.return_value = mock_redis
+    opts.new_rest_client.return_value = mock_rest_client
+    return opts
+
+
+@pytest.fixture
+def sut(mock_options):
+    return DailyRangeAnalyzer(mock_options)
+
+
+def _make_quote(symbol="AAPL", start_timestamp=REGULAR_TS, high=155.0, low=145.0, **extra):
+    return {"symbol": symbol, "start_timestamp": start_timestamp,
+            "high": high, "low": low, "close": 150.0, **extra}
+
+
+# ------------------------------------------------------------------
+# analyze_data — basic shape
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_returns_none_when_no_symbol(sut):
+    result = await sut.analyze_data({})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_returns_result_with_cache_key(sut, mock_rest_client):
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    result = await sut.analyze_data(_make_quote("AAPL"))
+    assert result is not None
+    assert len(result) == 1
+    assert isinstance(result[0], MarketDataAnalyzerResult)
+    assert result[0].cache_key == f"{WidgetDataCacheKeys.DAILY_RANGE.value}:AAPL"
+    assert result[0].cache_ttl == WidgetDataCacheTTL.DAILY_RANGE.value
+    assert result[0].publish_key == f"{WidgetDataCacheKeys.DAILY_RANGE.value}:AAPL"
+
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_payload_contains_session_hod_lod_fields(sut, mock_rest_client):
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    result = await sut.analyze_data(_make_quote("AAPL", high=170.0, low=160.0))
+    payload = result[0].data
+    assert "pre_market_high" in payload
+    assert "pre_market_low" in payload
+    assert "regular_session_high" in payload
+    assert "regular_session_low" in payload
+    assert "after_hours_high" in payload
+    assert "after_hours_low" in payload
+
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_payload_contains_no_enrichment_fields(sut, mock_rest_client):
+    """DailyRangeAnalyzer must not include any enrichment fields."""
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    result = await sut.analyze_data(_make_quote("AAPL"))
+    payload = result[0].data
+    for field in ("name", "description", "market_cap", "short_interest",
+                  "days_to_cover", "short_volume_ratio", "splits"):
+        assert field not in payload, f"Enrichment field '{field}' must not be in DailyRangeAnalyzer output"
+
+
+# ------------------------------------------------------------------
+# HOD/LOD tracking — regular session
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_updates_hod_lod_before_building_payload(sut, mock_rest_client):
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    result = await sut.analyze_data(_make_quote("AAPL", high=170.0, low=160.0))
+    payload = result[0].data
+    assert payload["regular_session_high"] == 170.0
+    assert payload["regular_session_low"] == 160.0
+
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_tracks_running_high_across_multiple_ticks(sut, mock_rest_client):
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    await sut.analyze_data(_make_quote("AAPL", high=170.0, low=160.0))
+    result = await sut.analyze_data(_make_quote("AAPL", high=175.0, low=162.0))
+    assert result[0].data["regular_session_high"] == 175.0
+    assert result[0].data["regular_session_low"] == 160.0
+
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_does_not_lower_hod_on_weaker_tick(sut, mock_rest_client):
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    await sut.analyze_data(_make_quote("AAPL", high=170.0, low=150.0))
+    result = await sut.analyze_data(_make_quote("AAPL", high=165.0, low=155.0))
+    assert result[0].data["regular_session_high"] == 170.0
+    assert result[0].data["regular_session_low"] == 150.0
+
+
+# ------------------------------------------------------------------
+# HOD/LOD tracking — pre-market
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_tracks_pre_market_hod_lod(sut, mock_rest_client):
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="extended-hours", early_hours=True, after_hours=False
+    )
+    result = await sut.analyze_data(_make_quote("AAPL", high=152.0, low=148.0))
+    payload = result[0].data
+    assert payload["pre_market_high"] == 152.0
+    assert payload["pre_market_low"] == 148.0
+    assert payload["regular_session_high"] is None
+    assert payload["after_hours_high"] is None
+
+
+# ------------------------------------------------------------------
+# HOD/LOD tracking — after-hours
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_tracks_after_hours_hod_lod(sut, mock_rest_client):
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="extended-hours", early_hours=False, after_hours=True
+    )
+    result = await sut.analyze_data(_make_quote("AAPL", high=160.0, low=155.0))
+    payload = result[0].data
+    assert payload["after_hours_high"] == 160.0
+    assert payload["after_hours_low"] == 155.0
+    assert payload["regular_session_high"] is None
+    assert payload["pre_market_high"] is None
+
+
+# ------------------------------------------------------------------
+# Market closed — no HOD/LOD update
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_does_not_update_hod_lod_when_market_closed(sut, mock_rest_client):
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="closed", early_hours=False, after_hours=False
+    )
+    result = await sut.analyze_data(_make_quote("AAPL", high=160.0, low=155.0))
+    payload = result[0].data
+    assert payload["regular_session_high"] is None
+    assert payload["regular_session_low"] is None
+
+
+# ------------------------------------------------------------------
+# _get_market_status — cache + failure
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_get_market_status_fetches_on_first_call(sut, mock_rest_client):
+    status = MarketStatus(market="open", early_hours=False, after_hours=False)
+    mock_rest_client.get_market_status.return_value = status
+    result = await sut._get_market_status()
+    assert result is status
+    mock_rest_client.get_market_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dra_get_market_status_returns_cached_within_60s(sut, mock_rest_client):
+    cached = MarketStatus(market="open", early_hours=False, after_hours=False)
+    sut._market_status = cached
+    sut._market_status_fetched_at = time.monotonic()
+    result = await sut._get_market_status()
+    assert result is cached
+    mock_rest_client.get_market_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dra_get_market_status_refetches_after_60s(sut, mock_rest_client):
+    old = MarketStatus(market="closed", early_hours=False, after_hours=False)
+    fresh = MarketStatus(market="open", early_hours=False, after_hours=False)
+    sut._market_status = old
+    sut._market_status_fetched_at = time.monotonic() - 61
+    mock_rest_client.get_market_status.return_value = fresh
+    result = await sut._get_market_status()
+    assert result is fresh
+
+
+@pytest.mark.asyncio
+async def test_dra_get_market_status_returns_stale_on_api_failure(sut, mock_rest_client):
+    stale = MarketStatus(market="open", early_hours=False, after_hours=False)
+    sut._market_status = stale
+    sut._market_status_fetched_at = time.monotonic() - 61
+    mock_rest_client.get_market_status.side_effect = Exception("timeout")
+    result = await sut._get_market_status()
+    assert result is stale
+    mock_rest_client.get_market_status.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Day boundary reset
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_check_day_boundary_clears_all_hod_lod_dicts(sut, mock_redis):
+    sut._regular_session_high["AAPL"] = 170.0
+    sut._regular_session_low["AAPL"] = 160.0
+    sut._pre_market_high["AAPL"] = 152.0
+    sut._pre_market_low["AAPL"] = 148.0
+
+    # SET NX returns truthy value (key was set — first time today)
+    mock_redis.set = AsyncMock(return_value=True)
+
+    with patch(f"{MODULE}.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 4, 8, 5, 0, 0, tzinfo=ET)
+        await sut._check_day_boundary()
+
+    assert sut._regular_session_high == {}
+    assert sut._regular_session_low == {}
+    assert sut._pre_market_high == {}
+    assert sut._pre_market_low == {}
+
+
+@pytest.mark.asyncio
+async def test_dra_check_day_boundary_does_not_reset_before_4am(sut, mock_redis):
+    sut._regular_session_high["AAPL"] = 170.0
+
+    with patch(f"{MODULE}.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 4, 8, 3, 59, 0, tzinfo=ET)
+        await sut._check_day_boundary()
+
+    assert sut._regular_session_high == {"AAPL": 170.0}
+    mock_redis.set.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# Market open reset (9:30 AM ET)
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_check_market_open_reset_clears_pre_market_hod_lod(sut, mock_redis):
+    sut._pre_market_high["AAPL"] = 152.0
+    sut._pre_market_low["AAPL"] = 148.0
+    sut._regular_session_high["AAPL"] = 155.0  # Should NOT be cleared
+
+    mock_redis.set = AsyncMock(return_value=True)  # NX success
+
+    with patch(f"{MODULE}.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 4, 8, 9, 30, 0, tzinfo=ET)
+        await sut._check_market_open_reset()
+
+    assert sut._pre_market_high == {}
+    assert sut._pre_market_low == {}
+    assert sut._regular_session_high == {"AAPL": 155.0}
+
+
+@pytest.mark.asyncio
+async def test_dra_check_market_open_reset_does_not_reset_before_930am(sut, mock_redis):
+    sut._pre_market_high["AAPL"] = 152.0
+
+    with patch(f"{MODULE}.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 4, 8, 9, 29, 0, tzinfo=ET)
+        await sut._check_market_open_reset()
+
+    assert sut._pre_market_high == {"AAPL": 152.0}
+    mock_redis.set.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# run_in_executor usage
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_get_market_status_uses_run_in_executor(sut, mock_rest_client):
+    """get_market_status() must be called via run_in_executor."""
+    sut._market_status_fetched_at = 0.0
+    loop = asyncio.get_running_loop()
+    executor_calls = []
+
+    async def mock_run_in_executor(executor, func, *args):
+        executor_calls.append(func)
+        return func(*args)
+
+    with patch.object(loop, 'run_in_executor', side_effect=mock_run_in_executor):
+        await sut._get_market_status()
+
+    assert len(executor_calls) > 0, "get_market_status() must be called via run_in_executor"


### PR DESCRIPTION
## Summary

Replaces the REST-call-heavy `EnhancedQuoteAnalyzer` with a focused `DailyRangeAnalyzer` that does exactly one thing: track session highs and lows from the `quote:*` feed.

## What's in

- `DailyRangeAnalyzer` — pure stream processor, no REST enrichment
- Publishes to `daily_range:{symbol}` (new `WidgetDataCacheKeys.DAILY_RANGE`)
- Pre-market / regular / after-hours HOD/LOD tracking
- Day boundary reset at 4AM ET, market open reset at 9:30AM ET
- Market status via `run_in_executor` with 60s in-memory cache (only REST call)
- 19 tests

## What's not in (follow-up)

- Removal of `EnhancedQuoteAnalyzer` (separate PR — needs MDS server + widget migration first)
- Enrichment worker (separate issue — REST calls belong in a standalone service)

refs #85