### PR TITLE
fix: use str comparison instead of .decode() for Redis get() in DailyRangeAnalyzer

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -195,7 +195,7 @@ class DailyRangeAnalyzer(Analyzer):
         set_result = await self.redis_client.set(key, today, nx=True, ex=86400)
         if set_result is None:
             existing = await self.redis_client.get(key)
-            if existing and existing.decode() == today:
+            if existing and existing == today:  # redis.asyncio returns str, not bytes
                 return
 
         self.logger.info(f"Day boundary reset at {today}")

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -38,9 +38,9 @@ def mock_redis():
     redis = MagicMock()
     redis.eval = AsyncMock(return_value=0)
     # SET NX returns None when key already existed (no reset triggered).
-    # get() returns a bytes value matching today so the boundary guard exits early.
+    # get() returns a str value matching today so the boundary guard exits early.
     import datetime as _dt
-    _today = _dt.datetime.now(tz=ZoneInfo("America/New_York")).strftime("%Y-%m-%d").encode()
+    _today = _dt.datetime.now(tz=ZoneInfo("America/New_York")).strftime("%Y-%m-%d")  # redis.asyncio returns str, not bytes
     redis.set = AsyncMock(return_value=None)
     redis.get = AsyncMock(return_value=_today)
     redis.setex = AsyncMock()


### PR DESCRIPTION
redis.asyncio returns `str` from `get()`, not `bytes`. Calling `.decode()` on it raises `AttributeError: 'str' object has no attribute 'decode'` on every quote tick, crashing the MDS event loop.

Fix `_check_day_boundary` to compare `existing == today` directly.

refs #91