### PR TITLE
chore: relax Python floor from 3.14 to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Tom Pounders", email = "git@oldschool.engineer" },
 ]
 readme = "README.rst"
-requires-python = ">=3.14"
+requires-python = ">=3.12"
 license = {file = "LICENSE.txt"}
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
kuhl-haus-mdp-app runs on Python 3.12 and needs to take a dependency on kuhl-haus-mdp. The 3.14 floor was aspirational (free-threaded GIL) but not practically useful before 3.15+. Dropping to 3.12.