### PR TITLE
fix(DailyRangeAnalyzer): skip non-dict Redis values during rehydrate()

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -81,9 +81,10 @@ class DailyRangeAnalyzer(Analyzer):
         into the six in-memory session dicts. This prevents restarts from
         discarding data accumulated earlier in the trading day.
 
-        The existing day/market-open boundary guards in ``_check_day_boundary()``
-        and ``_check_market_open_reset()`` will clear stale rehydrated state at
-        the appropriate time boundaries on the next tick.
+        ``_check_day_boundary()`` will clear stale rehydrated state when a new
+        pre-market session is detected on the next tick. Pre-market H/L is frozen
+        (not cleared) at regular session open and remains in published payloads
+        for the duration of the trading day.
         """
         prefix = WidgetDataCacheKeys.DAILY_RANGE.value
         pattern = f"{prefix}:*"

--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -121,7 +121,8 @@ class DailyRangeAnalyzer(Analyzer):
             if cursor == 0:
                 break
 
-        self.logger.info(f"dra.rehydrate: restored {restored} symbol(s)")
+        self._last_session = await self._get_session()
+        self.logger.info(f"dra.rehydrate: restored {restored} symbol(s), session={self._last_session}")
 
     @tracer.start_as_current_span("dra.analyze_data")
     async def analyze_data(self, data: dict) -> Optional[List[MarketDataAnalyzerResult]]:

--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -65,6 +65,57 @@ class DailyRangeAnalyzer(Analyzer):
         self._market_status: Optional[MarketStatus] = None
         self._market_status_fetched_at: float = 0.0  # monotonic epoch seconds
 
+    @tracer.start_as_current_span("dra.rehydrate")
+    async def rehydrate(self):
+        """Restore session HOD/LOD state from Redis on startup.
+
+        Scans all ``daily_range:*`` keys and restores per-symbol H/L values
+        into the six in-memory session dicts. This prevents restarts from
+        discarding data accumulated earlier in the trading day.
+
+        The existing day/market-open boundary guards in ``_check_day_boundary()``
+        and ``_check_market_open_reset()`` will clear stale rehydrated state at
+        the appropriate time boundaries on the next tick.
+        """
+        prefix = WidgetDataCacheKeys.DAILY_RANGE.value
+        pattern = f"{prefix}:*"
+        cursor = 0
+        restored = 0
+
+        while True:
+            cursor, keys = await self.redis_client.scan(cursor=cursor, match=pattern, count=100)
+            for key in keys:
+                raw = await self.redis_client.get(key)
+                if not raw:
+                    continue
+                try:
+                    import json
+                    payload = json.loads(raw)
+                except Exception:
+                    continue
+
+                symbol = payload.get("symbol")
+                if not symbol:
+                    continue
+
+                def _restore(dict_: dict, field: str):
+                    val = payload.get(field)
+                    if val is not None:
+                        dict_[symbol] = float(val)
+
+                _restore(self._pre_market_high, "pre_market_high")
+                _restore(self._pre_market_low, "pre_market_low")
+                _restore(self._regular_session_high, "regular_session_high")
+                _restore(self._regular_session_low, "regular_session_low")
+                _restore(self._after_hours_high, "after_hours_high")
+                _restore(self._after_hours_low, "after_hours_low")
+                restored += 1
+
+            if cursor == 0:
+                break
+
+        self.logger.info(f"dra.rehydrate: restored {restored} symbol(s)")
+
     @tracer.start_as_current_span("dra.analyze_data")
     async def analyze_data(self, data: dict) -> Optional[List[MarketDataAnalyzerResult]]:
         """Process a quote event and publish session HOD/LOD results.

--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -102,6 +102,9 @@ class DailyRangeAnalyzer(Analyzer):
                 except Exception:
                     continue
 
+                if not isinstance(payload, dict):
+                    continue
+
                 symbol = payload.get("symbol")
                 if not symbol:
                     continue

--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -15,6 +15,7 @@ Boundary resets:
 """
 import asyncio
 import functools
+import json
 import logging
 import time
 from datetime import datetime, timezone
@@ -89,7 +90,6 @@ class DailyRangeAnalyzer(Analyzer):
                 if not raw:
                     continue
                 try:
-                    import json
                     payload = json.loads(raw)
                 except Exception:
                     continue

--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -3,22 +3,27 @@
 Subscribes to the ``quote:*`` feed and publishes per-symbol session
 high/low (pre-market, regular, after-hours) to ``daily_range:{symbol}``.
 
-No external API calls are made. All state is maintained in process memory
-and coordinated via lightweight Redis keys for boundary resets.
+All state is maintained in process memory with Redis-backed rehydration
+on startup so restarts do not lose intraday data.
 
 Session detection uses the Massive ``get_market_status()`` API (60-second
 in-memory cache) so exchange holidays and early closes are handled correctly.
 
-Boundary resets:
-- 4:00 AM ET: all six HOD/LOD dicts cleared (SET NX per-day guard on Redis)
-- 9:30 AM ET: pre-market HOD/LOD cleared (SET NX per-day guard on Redis)
+Pre-market H/L is frozen (not cleared) when the regular session opens —
+it remains visible in published payloads throughout the trading day.
+
+Day boundary reset:
+- Triggered by observing a transition to ``pre_market`` session after a
+  period of ``None`` (market closed). All six HOD/LOD dicts are cleared.
+  A Redis SET NX key scoped to the calendar date prevents duplicate resets
+  across restarts and replicas.
 """
 import asyncio
 import functools
 import json
 import logging
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional, List
 from zoneinfo import ZoneInfo
 
@@ -46,7 +51,6 @@ class DailyRangeAnalyzer(Analyzer):
     """
 
     DAY_BOUNDARY_KEY = "daily_range:day_boundary"
-    MARKET_OPEN_RESET_KEY = "daily_range:market_open_reset:{date}"
 
     def __init__(self, options: AnalyzerOptions):
         super().__init__(options)
@@ -65,6 +69,9 @@ class DailyRangeAnalyzer(Analyzer):
         # Market status cache (60-second TTL)
         self._market_status: Optional[MarketStatus] = None
         self._market_status_fetched_at: float = 0.0  # monotonic epoch seconds
+
+        # Last observed session — used to detect transitions for day-boundary reset
+        self._last_session: Optional[str] = None
 
     @tracer.start_as_current_span("dra.rehydrate")
     async def rehydrate(self):
@@ -132,7 +139,6 @@ class DailyRangeAnalyzer(Analyzer):
             return None
 
         await self._check_day_boundary()
-        await self._check_market_open_reset()
         await self._update_session_hod_lod(symbol, data)
 
         payload = {
@@ -231,22 +237,37 @@ class DailyRangeAnalyzer(Analyzer):
 
     @tracer.start_as_current_span("dra._check_day_boundary")
     async def _check_day_boundary(self):
-        """Reset all HOD/LOD dicts at 4:00 AM ET (start of pre-market).
+        """Reset all HOD/LOD dicts when a new pre-market session is detected.
 
-        Uses a Redis SET NX key scoped to the current date to ensure the
-        reset fires exactly once per day per instance.
+        Triggers on the session transition ``None \u2192 pre_market`` (market closed
+        \u2192 pre-market open). This is session-transition driven, not wall-clock
+        driven, so exchange holidays and early closes are handled correctly.
+
+        A Redis SET NX key scoped to the calendar date prevents duplicate
+        resets across restarts and replicas within the same trading day.
+
+        Pre-market H/L is intentionally **not** cleared when the regular session
+        opens — it is frozen at 9:30 AM and remains visible in published payloads
+        throughout the day. AH H/L is similarly preserved until the next day
+        boundary reset.
         """
-        et = ZoneInfo("America/New_York")
-        now_et = datetime.now(tz=et)
-        if now_et.hour < 4:
+        session = await self._get_session()
+
+        # Track session transitions; only act on closed → pre_market
+        prev_session = self._last_session
+        self._last_session = session
+
+        if not (prev_session is None and session == "pre_market"):
             return
 
-        today = now_et.strftime("%Y-%m-%d")
+        # New pre-market session detected — guard with a per-day Redis key
+        et = ZoneInfo("America/New_York")
+        today = datetime.now(tz=et).strftime("%Y-%m-%d")
         key = self.DAY_BOUNDARY_KEY
         set_result = await self.redis_client.set(key, today, nx=True, ex=86400)
         if set_result is None:
             existing = await self.redis_client.get(key)
-            if existing and existing == today:  # redis.asyncio returns str, not bytes
+            if existing and existing == today:
                 return
 
         self.logger.info(f"Day boundary reset at {today}")
@@ -256,25 +277,3 @@ class DailyRangeAnalyzer(Analyzer):
         self._regular_session_low.clear()
         self._after_hours_high.clear()
         self._after_hours_low.clear()
-
-    @tracer.start_as_current_span("dra._check_market_open_reset")
-    async def _check_market_open_reset(self):
-        """Clear pre-market HOD/LOD at 9:30 AM ET (regular session open).
-
-        Uses a Redis SET NX key scoped to the current date so the reset
-        fires exactly once per day per instance.
-        """
-        et = ZoneInfo("America/New_York")
-        now_et = datetime.now(tz=et)
-        if now_et.hour < 9 or (now_et.hour == 9 and now_et.minute < 30):
-            return
-
-        today = now_et.strftime("%Y-%m-%d")
-        key = self.MARKET_OPEN_RESET_KEY.format(date=today)
-        set_result = await self.redis_client.set(key, "1", nx=True, ex=86400)
-        if set_result is None:
-            return
-
-        self.logger.info(f"Market open reset for {today}")
-        self._pre_market_high.clear()
-        self._pre_market_low.clear()

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -1,4 +1,4 @@
-"""Tests for DailyRangeAnalyzer — session HOD/LOD tracking."""
+"""Tests for DailyRangeAnalyzer - session HOD/LOD tracking."""
 import asyncio
 import time
 import pytest
@@ -75,7 +75,7 @@ def _make_quote(symbol="AAPL", start_timestamp=REGULAR_TS, high=155.0, low=145.0
 
 
 # ------------------------------------------------------------------
-# analyze_data — basic shape
+# analyze_data - basic shape
 # ------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -127,7 +127,7 @@ async def test_dra_analyze_data_payload_contains_no_enrichment_fields(sut, mock_
 
 
 # ------------------------------------------------------------------
-# HOD/LOD tracking — regular session
+# HOD/LOD tracking - regular session
 # ------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -164,7 +164,7 @@ async def test_dra_analyze_data_does_not_lower_hod_on_weaker_tick(sut, mock_rest
 
 
 # ------------------------------------------------------------------
-# HOD/LOD tracking — pre-market
+# HOD/LOD tracking - pre-market
 # ------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -181,7 +181,7 @@ async def test_dra_analyze_data_tracks_pre_market_hod_lod(sut, mock_rest_client)
 
 
 # ------------------------------------------------------------------
-# HOD/LOD tracking — after-hours
+# HOD/LOD tracking - after-hours
 # ------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -198,7 +198,7 @@ async def test_dra_analyze_data_tracks_after_hours_hod_lod(sut, mock_rest_client
 
 
 # ------------------------------------------------------------------
-# Market closed — no HOD/LOD update
+# Market closed - no HOD/LOD update
 # ------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -213,7 +213,7 @@ async def test_dra_analyze_data_does_not_update_hod_lod_when_market_closed(sut, 
 
 
 # ------------------------------------------------------------------
-# _get_market_status — cache + failure
+# _get_market_status - cache + failure
 # ------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -268,7 +268,7 @@ async def test_dra_check_day_boundary_clears_all_hod_lod_dicts(sut, mock_redis):
     sut._pre_market_high["AAPL"] = 152.0
     sut._pre_market_low["AAPL"] = 148.0
 
-    # SET NX returns truthy value (key was set — first time today)
+    # SET NX returns truthy value (key was set - first time today)
     mock_redis.set = AsyncMock(return_value=True)
 
     with patch(f"{MODULE}.datetime") as mock_dt:
@@ -345,3 +345,166 @@ async def test_dra_get_market_status_uses_run_in_executor(sut, mock_rest_client)
         await sut._get_market_status()
 
     assert len(executor_calls) > 0, "get_market_status() must be called via run_in_executor"
+
+
+# ------------------------------------------------------------------
+# rehydrate - restore state from Redis on startup
+# ------------------------------------------------------------------
+
+def _make_cached_payload(symbol, pre_high=None, pre_low=None,
+                          reg_high=None, reg_low=None,
+                          ah_high=None, ah_low=None):
+    """Build a JSON payload as stored in Redis daily_range:{symbol}."""
+    import json
+    return json.dumps({
+        "symbol": symbol,
+        "pre_market_high": pre_high,
+        "pre_market_low": pre_low,
+        "regular_session_high": reg_high,
+        "regular_session_low": reg_low,
+        "after_hours_high": ah_high,
+        "after_hours_low": ah_low,
+    })
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_restores_all_six_session_fields_from_redis(mock_options):
+    # Arrange - two symbols with complete session data in Redis
+    aapl_payload = _make_cached_payload(
+        "AAPL", pre_high=153.0, pre_low=149.0,
+        reg_high=157.0, reg_low=151.0,
+        ah_high=155.0, ah_low=152.0,
+    )
+    tsla_payload = _make_cached_payload(
+        "TSLA", pre_high=250.0, pre_low=245.0,
+        reg_high=260.0, reg_low=248.0,
+        ah_high=258.0, ah_low=252.0,
+    )
+
+    redis = mock_options.new_redis_client.return_value
+    # scan returns both keys in one batch then cursor=0 to stop
+    redis.scan = AsyncMock(side_effect=[
+        (0, ["daily_range:AAPL", "daily_range:TSLA"])
+    ])
+    redis.get = AsyncMock(side_effect=[aapl_payload, tsla_payload])
+
+    sut = DailyRangeAnalyzer(mock_options)
+
+    # Act
+    await sut.rehydrate()
+
+    # Assert - all six dicts populated for both symbols
+    assert sut._pre_market_high == {"AAPL": 153.0, "TSLA": 250.0}
+    assert sut._pre_market_low == {"AAPL": 149.0, "TSLA": 245.0}
+    assert sut._regular_session_high == {"AAPL": 157.0, "TSLA": 260.0}
+    assert sut._regular_session_low == {"AAPL": 151.0, "TSLA": 248.0}
+    assert sut._after_hours_high == {"AAPL": 155.0, "TSLA": 258.0}
+    assert sut._after_hours_low == {"AAPL": 152.0, "TSLA": 252.0}
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_skips_null_session_values(mock_options):
+    # Arrange - AAPL has no pre-market data yet (market hasn't opened pre-market)
+    aapl_payload = _make_cached_payload(
+        "AAPL", pre_high=None, pre_low=None,
+        reg_high=157.0, reg_low=151.0,
+    )
+
+    redis = mock_options.new_redis_client.return_value
+    redis.scan = AsyncMock(return_value=(0, ["daily_range:AAPL"]))
+    redis.get = AsyncMock(return_value=aapl_payload)
+
+    sut = DailyRangeAnalyzer(mock_options)
+    await sut.rehydrate()
+
+    # Assert - null fields not inserted into dicts
+    assert "AAPL" not in sut._pre_market_high
+    assert "AAPL" not in sut._pre_market_low
+    assert sut._regular_session_high == {"AAPL": 157.0}
+    assert sut._regular_session_low == {"AAPL": 151.0}
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_skips_keys_with_missing_redis_value(mock_options):
+    # Arrange - key exists in scan but Redis returns None (expired or deleted)
+    redis = mock_options.new_redis_client.return_value
+    redis.scan = AsyncMock(return_value=(0, ["daily_range:AAPL"]))
+    redis.get = AsyncMock(return_value=None)
+
+    sut = DailyRangeAnalyzer(mock_options)
+    await sut.rehydrate()
+
+    # Assert - nothing restored, no exception
+    assert sut._pre_market_high == {}
+    assert sut._regular_session_high == {}
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_handles_empty_scan_result(mock_options):
+    # Arrange - no keys in Redis (first startup of the day)
+    redis = mock_options.new_redis_client.return_value
+    redis.scan = AsyncMock(return_value=(0, []))
+
+    sut = DailyRangeAnalyzer(mock_options)
+    await sut.rehydrate()
+
+    # Assert - all dicts remain empty, no exception
+    assert sut._pre_market_high == {}
+    assert sut._pre_market_low == {}
+    assert sut._regular_session_high == {}
+    assert sut._regular_session_low == {}
+    assert sut._after_hours_high == {}
+    assert sut._after_hours_low == {}
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_paginates_through_multiple_scan_batches(mock_options):
+    # Arrange - SCAN requires two round-trips (cursor non-zero then zero)
+    import json
+    aapl_payload = json.dumps({"symbol": "AAPL", "regular_session_high": 157.0, "regular_session_low": 151.0})
+    tsla_payload = json.dumps({"symbol": "TSLA", "regular_session_high": 260.0, "regular_session_low": 248.0})
+
+    redis = mock_options.new_redis_client.return_value
+    redis.scan = AsyncMock(side_effect=[
+        (42, ["daily_range:AAPL"]),   # first batch - cursor != 0
+        (0,  ["daily_range:TSLA"]),   # second batch - cursor == 0, stop
+    ])
+    redis.get = AsyncMock(side_effect=[aapl_payload, tsla_payload])
+
+    sut = DailyRangeAnalyzer(mock_options)
+    await sut.rehydrate()
+
+    # Assert - both symbols restored despite pagination
+    assert sut._regular_session_high == {"AAPL": 157.0, "TSLA": 260.0}
+    assert sut._regular_session_low == {"AAPL": 151.0, "TSLA": 248.0}
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_then_analyze_data_preserves_rehydrated_highs(mock_options, mock_rest_client):
+    # Arrange — AAPL rehydrated with reg session high of 157.0
+    import json, datetime as _dt
+    cached = json.dumps({
+        "symbol": "AAPL", "regular_session_high": 157.0, "regular_session_low": 151.0,
+    })
+    today_str = _dt.datetime.now(tz=ZoneInfo("America/New_York")).strftime("%Y-%m-%d")
+
+    redis = mock_options.new_redis_client.return_value
+    redis.scan = AsyncMock(return_value=(0, ["daily_range:AAPL"]))
+    # get() is called twice: once by rehydrate (returns JSON), then by
+    # _check_day_boundary (must return today's date string to avoid reset).
+    redis.get = AsyncMock(side_effect=[cached, today_str])
+
+    sut = DailyRangeAnalyzer(mock_options)
+    await sut.rehydrate()
+
+    # Act — new tick comes in with a lower high (156.0) during regular session
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    result = await sut.analyze_data(_make_quote("AAPL", high=156.0, low=152.0))
+
+    # Assert — rehydrated high (157.0) preserved; it’s still the day high
+    assert result is not None
+    payload = result[0].data
+    assert payload["regular_session_high"] == 157.0   # rehydrated value wins
+    assert payload["regular_session_low"] == 151.0    # rehydrated low preserved (152 > 151)

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -522,31 +522,36 @@ async def test_dra_rehydrate_paginates_through_multiple_scan_batches(mock_option
 
 @pytest.mark.asyncio
 async def test_dra_rehydrate_then_analyze_data_preserves_rehydrated_highs(mock_options, mock_rest_client):
-    # Arrange - AAPL rehydrated with reg session high of 157.0
+    # Arrange - AAPL rehydrated with pre-market data; market is currently in pre_market.
+    # This is the critical scenario: without seeding _last_session in rehydrate(),
+    # the first analyze_data() call would see None→pre_market and wipe rehydrated data.
     cached = json.dumps({
-        "symbol": "AAPL", "regular_session_high": 157.0, "regular_session_low": 151.0,
+        "symbol": "AAPL",
+        "pre_market_high": 153.0, "pre_market_low": 149.0,
+        "regular_session_high": 157.0, "regular_session_low": 151.0,
     })
+
+    # Market is currently in pre-market
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="closed", early_hours=True, after_hours=False
+    )
 
     redis = mock_options.new_redis_client.return_value
     redis.scan = AsyncMock(return_value=(0, ["daily_range:AAPL"]))
-    # get() called once by rehydrate; _check_day_boundary no longer hits Redis
-    # unless a closed→pre_market transition is detected.
     redis.get = AsyncMock(return_value=cached)
 
     sut = DailyRangeAnalyzer(mock_options)
     await sut.rehydrate()
 
-    # Act - new tick comes in with a lower high (156.0) during regular session
-    # _last_session starts as None after rehydrate; set it to regular to avoid
-    # triggering a day-boundary reset on the first analyze_data() call.
-    sut._last_session = "regular"
-    mock_rest_client.get_market_status.return_value = MarketStatus(
-        market="open", early_hours=False, after_hours=False
-    )
-    result = await sut.analyze_data(_make_quote("AAPL", high=156.0, low=152.0))
+    # rehydrate() must have seeded _last_session = 'pre_market'
+    assert sut._last_session == "pre_market"
 
-    # Assert - rehydrated high (157.0) preserved; it's still the day high
+    # Act - new pre-market tick arrives with a lower high (152.0)
+    result = await sut.analyze_data(_make_quote("AAPL", high=152.0, low=150.0))
+
+    # Assert - rehydrated reg session high (157.0) preserved; pre-market high stays at 153.0
     assert result is not None
     payload = result[0].data
-    assert payload["regular_session_high"] == 157.0   # rehydrated value wins
-    assert payload["regular_session_low"] == 151.0    # rehydrated low preserved (152 > 151)
+    assert payload["pre_market_high"] == 153.0         # rehydrated value wins (152 < 153)
+    assert payload["pre_market_low"] == 149.0          # rehydrated low preserved (150 > 149)
+    assert payload["regular_session_high"] == 157.0   # reg session data not wiped

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -1,5 +1,6 @@
-"""Tests for DailyRangeAnalyzer - session HOD/LOD tracking."""
+"""Tests for DailyRangeAnalyzer — session HOD/LOD tracking."""
 import asyncio
+import json
 import time
 import pytest
 from datetime import datetime
@@ -355,7 +356,6 @@ def _make_cached_payload(symbol, pre_high=None, pre_low=None,
                           reg_high=None, reg_low=None,
                           ah_high=None, ah_low=None):
     """Build a JSON payload as stored in Redis daily_range:{symbol}."""
-    import json
     return json.dumps({
         "symbol": symbol,
         "pre_market_high": pre_high,
@@ -460,7 +460,6 @@ async def test_dra_rehydrate_handles_empty_scan_result(mock_options):
 @pytest.mark.asyncio
 async def test_dra_rehydrate_paginates_through_multiple_scan_batches(mock_options):
     # Arrange - SCAN requires two round-trips (cursor non-zero then zero)
-    import json
     aapl_payload = json.dumps({"symbol": "AAPL", "regular_session_high": 157.0, "regular_session_low": 151.0})
     tsla_payload = json.dumps({"symbol": "TSLA", "regular_session_high": 260.0, "regular_session_low": 248.0})
 
@@ -481,8 +480,8 @@ async def test_dra_rehydrate_paginates_through_multiple_scan_batches(mock_option
 
 @pytest.mark.asyncio
 async def test_dra_rehydrate_then_analyze_data_preserves_rehydrated_highs(mock_options, mock_rest_client):
-    # Arrange — AAPL rehydrated with reg session high of 157.0
-    import json, datetime as _dt
+    # Arrange - AAPL rehydrated with reg session high of 157.0
+    import datetime as _dt
     cached = json.dumps({
         "symbol": "AAPL", "regular_session_high": 157.0, "regular_session_low": 151.0,
     })
@@ -497,13 +496,13 @@ async def test_dra_rehydrate_then_analyze_data_preserves_rehydrated_highs(mock_o
     sut = DailyRangeAnalyzer(mock_options)
     await sut.rehydrate()
 
-    # Act — new tick comes in with a lower high (156.0) during regular session
+    # Act - new tick comes in with a lower high (156.0) during regular session
     mock_rest_client.get_market_status.return_value = MarketStatus(
         market="open", early_hours=False, after_hours=False
     )
     result = await sut.analyze_data(_make_quote("AAPL", high=156.0, low=152.0))
 
-    # Assert — rehydrated high (157.0) preserved; it’s still the day high
+    # Assert - rehydrated high (157.0) preserved; it's still the day high
     assert result is not None
     payload = result[0].data
     assert payload["regular_session_high"] == 157.0   # rehydrated value wins

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -555,3 +555,32 @@ async def test_dra_rehydrate_then_analyze_data_preserves_rehydrated_highs(mock_o
     assert payload["pre_market_high"] == 153.0         # rehydrated value wins (152 < 153)
     assert payload["pre_market_low"] == 149.0          # rehydrated low preserved (150 > 149)
     assert payload["regular_session_high"] == 157.0   # reg session data not wiped
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_skips_non_dict_control_keys(mock_options):
+    # Arrange - scan returns both a valid symbol key AND the control keys
+    # (daily_range:day_boundary stores a date string; daily_range:market_open_reset:DATE
+    # stores "1"). json.loads on those returns str/int, not dict — must not crash.
+    aapl_payload = _make_cached_payload("AAPL", reg_high=157.0, reg_low=151.0)
+
+    redis = mock_options.new_redis_client.return_value
+    redis.scan = AsyncMock(return_value=(
+        0,
+        [
+            "daily_range:day_boundary",
+            "daily_range:market_open_reset:2026-04-14",
+            "daily_range:AAPL",
+        ],
+    ))
+    # Return values: date string, "1" (int after json.loads), then valid JSON
+    redis.get = AsyncMock(side_effect=["\"2026-04-14\"", "1", aapl_payload])
+
+    sut = DailyRangeAnalyzer(mock_options)
+
+    # Act - must not raise AttributeError: 'int'/'str' object has no attribute 'get'
+    await sut.rehydrate()
+
+    # Assert - AAPL restored; control keys silently skipped
+    assert sut._regular_session_high == {"AAPL": 157.0}
+    assert sut._regular_session_low == {"AAPL": 151.0}

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -259,72 +259,114 @@ async def test_dra_get_market_status_returns_stale_on_api_failure(sut, mock_rest
 
 
 # ------------------------------------------------------------------
-# Day boundary reset
+# Day boundary reset — session-transition driven
 # ------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_dra_check_day_boundary_clears_all_hod_lod_dicts(sut, mock_redis):
+async def test_dra_check_day_boundary_clears_all_hod_lod_dicts_on_closed_to_pre_market(sut, mock_redis):
+    # Arrange — previous session was None (closed), now pre_market
+    sut._last_session = None
     sut._regular_session_high["AAPL"] = 170.0
     sut._regular_session_low["AAPL"] = 160.0
     sut._pre_market_high["AAPL"] = 152.0
     sut._pre_market_low["AAPL"] = 148.0
+    mock_redis.set = AsyncMock(return_value=True)  # SET NX succeeds
 
-    # SET NX returns truthy value (key was set - first time today)
-    mock_redis.set = AsyncMock(return_value=True)
-
-    with patch(f"{MODULE}.datetime") as mock_dt:
-        mock_dt.now.return_value = datetime(2026, 4, 8, 5, 0, 0, tzinfo=ET)
+    with patch.object(sut, "_get_session", return_value="pre_market"):
         await sut._check_day_boundary()
 
     assert sut._regular_session_high == {}
     assert sut._regular_session_low == {}
     assert sut._pre_market_high == {}
     assert sut._pre_market_low == {}
+    assert sut._last_session == "pre_market"
 
 
 @pytest.mark.asyncio
-async def test_dra_check_day_boundary_does_not_reset_before_4am(sut, mock_redis):
-    sut._regular_session_high["AAPL"] = 170.0
+async def test_dra_check_day_boundary_does_not_reset_when_already_in_pre_market(sut, mock_redis):
+    # Arrange — already in pre_market, no transition
+    sut._last_session = "pre_market"
+    sut._pre_market_high["AAPL"] = 152.0
 
-    with patch(f"{MODULE}.datetime") as mock_dt:
-        mock_dt.now.return_value = datetime(2026, 4, 8, 3, 59, 0, tzinfo=ET)
+    with patch.object(sut, "_get_session", return_value="pre_market"):
         await sut._check_day_boundary()
-
-    assert sut._regular_session_high == {"AAPL": 170.0}
-    mock_redis.set.assert_not_called()
-
-
-# ------------------------------------------------------------------
-# Market open reset (9:30 AM ET)
-# ------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_dra_check_market_open_reset_clears_pre_market_hod_lod(sut, mock_redis):
-    sut._pre_market_high["AAPL"] = 152.0
-    sut._pre_market_low["AAPL"] = 148.0
-    sut._regular_session_high["AAPL"] = 155.0  # Should NOT be cleared
-
-    mock_redis.set = AsyncMock(return_value=True)  # NX success
-
-    with patch(f"{MODULE}.datetime") as mock_dt:
-        mock_dt.now.return_value = datetime(2026, 4, 8, 9, 30, 0, tzinfo=ET)
-        await sut._check_market_open_reset()
-
-    assert sut._pre_market_high == {}
-    assert sut._pre_market_low == {}
-    assert sut._regular_session_high == {"AAPL": 155.0}
-
-
-@pytest.mark.asyncio
-async def test_dra_check_market_open_reset_does_not_reset_before_930am(sut, mock_redis):
-    sut._pre_market_high["AAPL"] = 152.0
-
-    with patch(f"{MODULE}.datetime") as mock_dt:
-        mock_dt.now.return_value = datetime(2026, 4, 8, 9, 29, 0, tzinfo=ET)
-        await sut._check_market_open_reset()
 
     assert sut._pre_market_high == {"AAPL": 152.0}
     mock_redis.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dra_check_day_boundary_does_not_reset_on_regular_session(sut, mock_redis):
+    # Arrange — pre_market → regular is NOT a day boundary
+    sut._last_session = "pre_market"
+    sut._pre_market_high["AAPL"] = 152.0
+
+    with patch.object(sut, "_get_session", return_value="regular"):
+        await sut._check_day_boundary()
+
+    assert sut._pre_market_high == {"AAPL": 152.0}
+    mock_redis.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dra_check_day_boundary_redis_guard_prevents_double_reset(sut, mock_redis):
+    # Arrange — SET NX returns None (key already exists for today)
+    sut._last_session = None
+    sut._pre_market_high["AAPL"] = 152.0
+    mock_redis.set = AsyncMock(return_value=None)  # NX failed
+    import datetime as _dt
+    today = _dt.datetime.now(tz=ET).strftime("%Y-%m-%d")
+    mock_redis.get = AsyncMock(return_value=today)
+
+    with patch.object(sut, "_get_session", return_value="pre_market"):
+        await sut._check_day_boundary()
+
+    # Guard fired — reset did NOT happen
+    assert sut._pre_market_high == {"AAPL": 152.0}
+
+
+# ------------------------------------------------------------------
+# Pre-market H/L preserved during regular session and after-hours
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_pre_market_hod_lod_visible_in_regular_session_payload(sut, mock_rest_client):
+    # Pre-market H/L must remain in published payload during regular session.
+    # This was broken when _check_market_open_reset() cleared the dicts.
+    sut._pre_market_high["AAPL"] = 153.0
+    sut._pre_market_low["AAPL"] = 149.0
+
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    result = await sut.analyze_data(_make_quote("AAPL", high=156.0, low=151.0))
+
+    assert result is not None
+    payload = result[0].data
+    assert payload["pre_market_high"] == 153.0
+    assert payload["pre_market_low"] == 149.0
+    assert payload["regular_session_high"] == 156.0
+    assert payload["regular_session_low"] == 151.0
+
+
+@pytest.mark.asyncio
+async def test_dra_pre_market_and_regular_hod_lod_visible_in_after_hours_payload(sut, mock_rest_client):
+    # Pre-market AND regular session H/L must remain visible after hours.
+    sut._pre_market_high["AAPL"] = 153.0
+    sut._pre_market_low["AAPL"] = 149.0
+    sut._regular_session_high["AAPL"] = 158.0
+    sut._regular_session_low["AAPL"] = 150.0
+
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="closed", early_hours=False, after_hours=True
+    )
+    result = await sut.analyze_data(_make_quote("AAPL", high=155.0, low=152.0))
+
+    assert result is not None
+    payload = result[0].data
+    assert payload["pre_market_high"] == 153.0
+    assert payload["regular_session_high"] == 158.0
+    assert payload["after_hours_high"] == 155.0
 
 
 # ------------------------------------------------------------------
@@ -481,22 +523,23 @@ async def test_dra_rehydrate_paginates_through_multiple_scan_batches(mock_option
 @pytest.mark.asyncio
 async def test_dra_rehydrate_then_analyze_data_preserves_rehydrated_highs(mock_options, mock_rest_client):
     # Arrange - AAPL rehydrated with reg session high of 157.0
-    import datetime as _dt
     cached = json.dumps({
         "symbol": "AAPL", "regular_session_high": 157.0, "regular_session_low": 151.0,
     })
-    today_str = _dt.datetime.now(tz=ZoneInfo("America/New_York")).strftime("%Y-%m-%d")
 
     redis = mock_options.new_redis_client.return_value
     redis.scan = AsyncMock(return_value=(0, ["daily_range:AAPL"]))
-    # get() is called twice: once by rehydrate (returns JSON), then by
-    # _check_day_boundary (must return today's date string to avoid reset).
-    redis.get = AsyncMock(side_effect=[cached, today_str])
+    # get() called once by rehydrate; _check_day_boundary no longer hits Redis
+    # unless a closed→pre_market transition is detected.
+    redis.get = AsyncMock(return_value=cached)
 
     sut = DailyRangeAnalyzer(mock_options)
     await sut.rehydrate()
 
     # Act - new tick comes in with a lower high (156.0) during regular session
+    # _last_session starts as None after rehydrate; set it to regular to avoid
+    # triggering a day-boundary reset on the first analyze_data() call.
+    sut._last_session = "regular"
     mock_rest_client.get_market_status.return_value = MarketStatus(
         market="open", early_hours=False, after_hours=False
     )


### PR DESCRIPTION
## Problem

`daily_range:day_boundary` and `daily_range:market_open_reset:*` keys share the `daily_range:*` prefix. `json.loads` on their values returns `str`/`int` (not `dict`), causing:

```
AttributeError: 'int' object has no attribute 'get'
```

on the first `payload.get('symbol')` call — crashing MDS on startup after the rehydrate() implementation landed.

## Fix

Add `isinstance(payload, dict)` guard immediately after `json.loads` to silently skip control keys.

## Test

Added `test_dra_rehydrate_skips_non_dict_control_keys`: scan returns `day_boundary`, `market_open_reset:DATE`, and a valid symbol key. The test asserts no exception is raised and the valid symbol is still restored.

695/695 tests passing.

refs #95