### PR TITLE
fix(DailyRangeAnalyzer): skip non-dict Redis values during rehydrate()

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -102,6 +102,9 @@ class DailyRangeAnalyzer(Analyzer):
                 except Exception:
                     continue
 
+                if not isinstance(payload, dict):
+                    continue
+
                 symbol = payload.get("symbol")
                 if not symbol:
                     continue

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -555,3 +555,31 @@ async def test_dra_rehydrate_then_analyze_data_preserves_rehydrated_highs(mock_o
     assert payload["pre_market_high"] == 153.0         # rehydrated value wins (152 < 153)
     assert payload["pre_market_low"] == 149.0          # rehydrated low preserved (150 > 149)
     assert payload["regular_session_high"] == 157.0   # reg session data not wiped
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_skips_non_dict_control_keys(mock_options):
+    # Arrange - scan returns the day-boundary control key alongside a valid symbol key.
+    # daily_range:day_boundary stores a date string; json.loads returns str, not dict.
+    # The isinstance(payload, dict) guard must skip it without raising AttributeError.
+    aapl_payload = _make_cached_payload("AAPL", reg_high=157.0, reg_low=151.0)
+
+    redis = mock_options.new_redis_client.return_value
+    redis.scan = AsyncMock(return_value=(
+        0,
+        [
+            "daily_range:day_boundary",
+            "daily_range:AAPL",
+        ],
+    ))
+    # Return values: date string (str after json.loads), then valid JSON object
+    redis.get = AsyncMock(side_effect=["\"2026-04-14\"", aapl_payload])
+
+    sut = DailyRangeAnalyzer(mock_options)
+
+    # Act - must not raise AttributeError: 'str' object has no attribute 'get'
+    await sut.rehydrate()
+
+    # Assert - AAPL restored; control key silently skipped
+    assert sut._regular_session_high == {"AAPL": 157.0}
+    assert sut._regular_session_low == {"AAPL": 151.0}


### PR DESCRIPTION
## Problem

`daily_range:day_boundary` and `daily_range:market_open_reset:*` keys share the `daily_range:*` prefix. `json.loads` on their values returns `str`/`int` (not `dict`), causing:

```
AttributeError: 'int' object has no attribute 'get'
```

on the first `payload.get('symbol')` call — crashing MDS on startup after the rehydrate() implementation landed in v0.4.9.

## Fix

Add `isinstance(payload, dict)` guard immediately after `json.loads` to silently skip control keys.

## Test

Added `test_dra_rehydrate_skips_non_dict_control_keys`: scan returns `day_boundary`, `market_open_reset:DATE`, and a valid symbol key. Asserts no exception is raised and the valid symbol is still restored.

695/695 tests passing.

refs #95