### PR TITLE
fix(DailyRangeAnalyzer): scope rehydrate() to sessions elapsed today

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -78,14 +78,57 @@ class DailyRangeAnalyzer(Analyzer):
         """Restore session HOD/LOD state from Redis on startup.
 
         Scans all ``daily_range:*`` keys and restores per-symbol H/L values
-        into the six in-memory session dicts. This prevents restarts from
-        discarding data accumulated earlier in the trading day.
+        into the in-memory session dicts for sessions that have already
+        elapsed today.
 
-        ``_check_day_boundary()`` will clear stale rehydrated state when a new
-        pre-market session is detected on the next tick. Pre-market H/L is frozen
-        (not cleared) at regular session open and remains in published payloads
-        for the duration of the trading day.
+        Only fields from sessions that have already occurred are restored:
+
+        - ``pre_market``  → pre-market fields only
+        - ``regular``     → pre-market + regular-session fields
+        - ``after_hours`` → all six fields
+        - ``None``        → nothing (market closed; cannot determine which
+          trading day the cached data belongs to)
+
+        This prevents yesterday's regular/after-hours values from leaking
+        into today's pre-market display on restart.
+
+        Pre-market H/L is intentionally preserved through the regular session
+        open and remains visible in published payloads throughout the day.
         """
+        current_session = await self._get_session()
+
+        # Determine which session fields are valid for today so far.
+        # Sessions only accumulate forward; restoring future-session fields
+        # would surface yesterday's data until overwritten.
+        if current_session == "pre_market":
+            restore_fields = [
+                (self._pre_market_high, "pre_market_high"),
+                (self._pre_market_low, "pre_market_low"),
+            ]
+        elif current_session == "regular":
+            restore_fields = [
+                (self._pre_market_high, "pre_market_high"),
+                (self._pre_market_low, "pre_market_low"),
+                (self._regular_session_high, "regular_session_high"),
+                (self._regular_session_low, "regular_session_low"),
+            ]
+        elif current_session == "after_hours":
+            restore_fields = [
+                (self._pre_market_high, "pre_market_high"),
+                (self._pre_market_low, "pre_market_low"),
+                (self._regular_session_high, "regular_session_high"),
+                (self._regular_session_low, "regular_session_low"),
+                (self._after_hours_high, "after_hours_high"),
+                (self._after_hours_low, "after_hours_low"),
+            ]
+        else:
+            # Market closed — cannot safely determine which day the cached
+            # data belongs to; skip rehydration and let the day-boundary
+            # reset handle cleanup on the next pre-market transition.
+            self._last_session = current_session
+            self.logger.info("dra.rehydrate: market closed — skipping rehydration")
+            return
+
         prefix = WidgetDataCacheKeys.DAILY_RANGE.value
         pattern = f"{prefix}:*"
         cursor = 0
@@ -109,23 +152,17 @@ class DailyRangeAnalyzer(Analyzer):
                 if not symbol:
                     continue
 
-                def _restore(dict_: dict, field: str):
+                for dict_, field in restore_fields:
                     val = payload.get(field)
                     if val is not None:
                         dict_[symbol] = float(val)
 
-                _restore(self._pre_market_high, "pre_market_high")
-                _restore(self._pre_market_low, "pre_market_low")
-                _restore(self._regular_session_high, "regular_session_high")
-                _restore(self._regular_session_low, "regular_session_low")
-                _restore(self._after_hours_high, "after_hours_high")
-                _restore(self._after_hours_low, "after_hours_low")
                 restored += 1
 
             if cursor == 0:
                 break
 
-        self._last_session = await self._get_session()
+        self._last_session = current_session
         self.logger.info(f"dra.rehydrate: restored {restored} symbol(s), session={self._last_session}")
 
     @tracer.start_as_current_span("dra.analyze_data")

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -410,8 +410,11 @@ def _make_cached_payload(symbol, pre_high=None, pre_low=None,
 
 
 @pytest.mark.asyncio
-async def test_dra_rehydrate_restores_all_six_session_fields_from_redis(mock_options):
-    # Arrange - two symbols with complete session data in Redis
+async def test_dra_rehydrate_during_after_hours_restores_all_six_fields(mock_options):
+    # Arrange - after-hours session: all six fields are valid for today.
+    mock_options.new_rest_client.return_value.get_market_status.return_value = MarketStatus(
+        market="closed", early_hours=False, after_hours=True
+    )
     aapl_payload = _make_cached_payload(
         "AAPL", pre_high=153.0, pre_low=149.0,
         reg_high=157.0, reg_low=151.0,
@@ -424,15 +427,12 @@ async def test_dra_rehydrate_restores_all_six_session_fields_from_redis(mock_opt
     )
 
     redis = mock_options.new_redis_client.return_value
-    # scan returns both keys in one batch then cursor=0 to stop
     redis.scan = AsyncMock(side_effect=[
         (0, ["daily_range:AAPL", "daily_range:TSLA"])
     ])
     redis.get = AsyncMock(side_effect=[aapl_payload, tsla_payload])
 
     sut = DailyRangeAnalyzer(mock_options)
-
-    # Act
     await sut.rehydrate()
 
     # Assert - all six dicts populated for both symbols
@@ -446,7 +446,8 @@ async def test_dra_rehydrate_restores_all_six_session_fields_from_redis(mock_opt
 
 @pytest.mark.asyncio
 async def test_dra_rehydrate_skips_null_session_values(mock_options):
-    # Arrange - AAPL has no pre-market data yet (market hasn't opened pre-market)
+    # Arrange - regular session; AAPL has no pre-market data (e.g. gapped up at open)
+    # mock_options defaults to market="open" (regular session)
     aapl_payload = _make_cached_payload(
         "AAPL", pre_high=None, pre_low=None,
         reg_high=157.0, reg_low=151.0,
@@ -459,7 +460,7 @@ async def test_dra_rehydrate_skips_null_session_values(mock_options):
     sut = DailyRangeAnalyzer(mock_options)
     await sut.rehydrate()
 
-    # Assert - null fields not inserted into dicts
+    # Assert - null pre-market fields not inserted; regular fields restored
     assert "AAPL" not in sut._pre_market_high
     assert "AAPL" not in sut._pre_market_low
     assert sut._regular_session_high == {"AAPL": 157.0}
@@ -501,7 +502,7 @@ async def test_dra_rehydrate_handles_empty_scan_result(mock_options):
 
 @pytest.mark.asyncio
 async def test_dra_rehydrate_paginates_through_multiple_scan_batches(mock_options):
-    # Arrange - SCAN requires two round-trips (cursor non-zero then zero)
+    # Arrange - regular session (mock_options default); SCAN requires two round-trips
     aapl_payload = json.dumps({"symbol": "AAPL", "regular_session_high": 157.0, "regular_session_low": 151.0})
     tsla_payload = json.dumps({"symbol": "TSLA", "regular_session_high": 260.0, "regular_session_low": 248.0})
 
@@ -522,13 +523,12 @@ async def test_dra_rehydrate_paginates_through_multiple_scan_batches(mock_option
 
 @pytest.mark.asyncio
 async def test_dra_rehydrate_then_analyze_data_preserves_rehydrated_highs(mock_options, mock_rest_client):
-    # Arrange - AAPL rehydrated with pre-market data; market is currently in pre_market.
-    # This is the critical scenario: without seeding _last_session in rehydrate(),
-    # the first analyze_data() call would see None→pre_market and wipe rehydrated data.
+    # Arrange - AAPL rehydrated during pre-market; market is currently in pre_market.
+    # Critical scenario: without seeding _last_session in rehydrate(), the first
+    # analyze_data() call would see None→pre_market transition and wipe rehydrated data.
     cached = json.dumps({
         "symbol": "AAPL",
         "pre_market_high": 153.0, "pre_market_low": 149.0,
-        "regular_session_high": 157.0, "regular_session_low": 151.0,
     })
 
     # Market is currently in pre-market
@@ -549,17 +549,19 @@ async def test_dra_rehydrate_then_analyze_data_preserves_rehydrated_highs(mock_o
     # Act - new pre-market tick arrives with a lower high (152.0)
     result = await sut.analyze_data(_make_quote("AAPL", high=152.0, low=150.0))
 
-    # Assert - rehydrated reg session high (157.0) preserved; pre-market high stays at 153.0
+    # Assert - rehydrated pre-market high (153.0) preserved; incoming 152.0 does not displace it
     assert result is not None
     payload = result[0].data
-    assert payload["pre_market_high"] == 153.0         # rehydrated value wins (152 < 153)
-    assert payload["pre_market_low"] == 149.0          # rehydrated low preserved (150 > 149)
-    assert payload["regular_session_high"] == 157.0   # reg session data not wiped
+    assert payload["pre_market_high"] == 153.0   # rehydrated value wins (152 < 153)
+    assert payload["pre_market_low"] == 149.0    # rehydrated low preserved (150 > 149)
+    assert payload["regular_session_high"] is None   # not yet in regular session
+    assert payload["after_hours_high"] is None        # not yet in after-hours session
 
 
 @pytest.mark.asyncio
 async def test_dra_rehydrate_skips_non_dict_control_keys(mock_options):
-    # Arrange - scan returns the day-boundary control key alongside a valid symbol key.
+    # Arrange - regular session (mock_options default); scan returns the day-boundary
+    # control key alongside a valid symbol key.
     # daily_range:day_boundary stores a date string; json.loads returns str, not dict.
     # The isinstance(payload, dict) guard must skip it without raising AttributeError.
     aapl_payload = _make_cached_payload("AAPL", reg_high=157.0, reg_low=151.0)
@@ -583,3 +585,89 @@ async def test_dra_rehydrate_skips_non_dict_control_keys(mock_options):
     # Assert - AAPL restored; control key silently skipped
     assert sut._regular_session_high == {"AAPL": 157.0}
     assert sut._regular_session_low == {"AAPL": 151.0}
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_during_pre_market_restores_only_pre_market_fields(mock_options):
+    # Arrange - pre-market session: only pre-market fields are valid for today.
+    # Regular and after-hours values in the cached payload are from yesterday
+    # and must NOT be restored.
+    mock_options.new_rest_client.return_value.get_market_status.return_value = MarketStatus(
+        market="closed", early_hours=True, after_hours=False
+    )
+    aapl_payload = _make_cached_payload(
+        "AAPL",
+        pre_high=153.0, pre_low=149.0,
+        reg_high=165.0, reg_low=158.0,    # yesterday's regular — must be ignored
+        ah_high=162.0, ah_low=160.0,      # yesterday's after-hours — must be ignored
+    )
+
+    redis = mock_options.new_redis_client.return_value
+    redis.scan = AsyncMock(return_value=(0, ["daily_range:AAPL"]))
+    redis.get = AsyncMock(return_value=aapl_payload)
+
+    sut = DailyRangeAnalyzer(mock_options)
+    await sut.rehydrate()
+
+    # Assert - only pre-market fields restored; regular and AH dicts empty
+    assert sut._pre_market_high == {"AAPL": 153.0}
+    assert sut._pre_market_low == {"AAPL": 149.0}
+    assert sut._regular_session_high == {}
+    assert sut._regular_session_low == {}
+    assert sut._after_hours_high == {}
+    assert sut._after_hours_low == {}
+    assert sut._last_session == "pre_market"
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_during_regular_session_excludes_after_hours_fields(mock_options):
+    # Arrange - regular session (mock_options default: market="open").
+    # After-hours values in the cached payload are from yesterday and must NOT be restored.
+    aapl_payload = _make_cached_payload(
+        "AAPL",
+        pre_high=153.0, pre_low=149.0,
+        reg_high=157.0, reg_low=151.0,
+        ah_high=162.0, ah_low=160.0,      # yesterday's after-hours — must be ignored
+    )
+
+    redis = mock_options.new_redis_client.return_value
+    redis.scan = AsyncMock(return_value=(0, ["daily_range:AAPL"]))
+    redis.get = AsyncMock(return_value=aapl_payload)
+
+    sut = DailyRangeAnalyzer(mock_options)
+    await sut.rehydrate()
+
+    # Assert - pre-market and regular fields restored; AH dict empty
+    assert sut._pre_market_high == {"AAPL": 153.0}
+    assert sut._pre_market_low == {"AAPL": 149.0}
+    assert sut._regular_session_high == {"AAPL": 157.0}
+    assert sut._regular_session_low == {"AAPL": 151.0}
+    assert sut._after_hours_high == {}
+    assert sut._after_hours_low == {}
+    assert sut._last_session == "regular"
+
+
+@pytest.mark.asyncio
+async def test_dra_rehydrate_when_market_closed_skips_rehydration(mock_options):
+    # Arrange - market closed (not in any active session). Cannot determine whether
+    # cached data is from today or yesterday; skip rehydration entirely.
+    mock_options.new_rest_client.return_value.get_market_status.return_value = MarketStatus(
+        market="closed", early_hours=False, after_hours=False
+    )
+
+    redis = mock_options.new_redis_client.return_value
+    # scan should never be called
+    redis.scan = AsyncMock(return_value=(0, ["daily_range:AAPL"]))
+    aapl_payload = _make_cached_payload(
+        "AAPL", pre_high=153.0, pre_low=149.0, reg_high=157.0, reg_low=151.0
+    )
+    redis.get = AsyncMock(return_value=aapl_payload)
+
+    sut = DailyRangeAnalyzer(mock_options)
+    await sut.rehydrate()
+
+    # Assert - all dicts empty; scan never called
+    assert sut._pre_market_high == {}
+    assert sut._regular_session_high == {}
+    assert sut._after_hours_high == {}
+    redis.scan.assert_not_called()


### PR DESCRIPTION
## Problem

`rehydrate()` restored all six HOD/LOD session fields unconditionally, so yesterday's regular-session and after-hours values persisted into the next day until overwritten by new ticks:

- **Pre-market**: regular and after-hours dicts populated with yesterday's values
- **Regular session**: after-hours dict populated with yesterday's values
- **After-hours**: correct (all six fields are today's)

## Fix

Determine the current session before scanning. Only restore fields from sessions that have already elapsed today:

| Session | Fields restored |
|---|---|
| `pre_market` | pre-market only |
| `regular` | pre-market + regular |
| `after_hours` | all six |
| `None` (closed) | nothing — cannot determine which trading day the cached data belongs to |

## Tests

3 new tests covering each session scope:
- `test_dra_rehydrate_during_pre_market_restores_only_pre_market_fields`
- `test_dra_rehydrate_during_regular_session_excludes_after_hours_fields`
- `test_dra_rehydrate_when_market_closed_skips_rehydration`

698/698 tests passing.

refs #95