### PR TITLE
feat(DailyRangeAnalyzer): emit HOD/LOD alert events on new session extremes

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -24,7 +24,7 @@ import json
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Optional, List
+from typing import List, Optional
 from zoneinfo import ZoneInfo
 
 from massive.rest.models import MarketStatus
@@ -169,11 +169,19 @@ class DailyRangeAnalyzer(Analyzer):
     async def analyze_data(self, data: dict) -> Optional[List[MarketDataAnalyzerResult]]:
         """Process a quote event and publish session HOD/LOD results.
 
+        Returns a list of one or more ``MarketDataAnalyzerResult`` entries:
+
+        - Always: one state result published to ``daily_range:{symbol}``.
+        - Conditionally: one alert result per new session extreme (HOD or LOD),
+          published to ``daily_range_hod_alert`` or ``daily_range_lod_alert``.
+          Alerts are suppressed on the first tick for a symbol (no prior value
+          to compare against) and after day-boundary resets.
+
         Args:
             data: Quote event dict from the ``quote:*`` feed.
 
         Returns:
-            List with a single ``MarketDataAnalyzerResult`` for the symbol,
+            List of ``MarketDataAnalyzerResult`` (state first, alerts appended),
             or ``None`` if the event could not be processed.
         """
         symbol = data.get("sym") or data.get("symbol")
@@ -181,7 +189,7 @@ class DailyRangeAnalyzer(Analyzer):
             return None
 
         await self._check_day_boundary()
-        await self._update_session_hod_lod(symbol, data)
+        alert_results = await self._update_session_hod_lod(symbol, data)
 
         payload = {
             **data,
@@ -194,12 +202,13 @@ class DailyRangeAnalyzer(Analyzer):
         }
 
         cache_key = f"{WidgetDataCacheKeys.DAILY_RANGE.value}:{symbol}"
-        return [MarketDataAnalyzerResult(
+        state_result = MarketDataAnalyzerResult(
             data=payload,
             cache_key=cache_key,
             cache_ttl=WidgetDataCacheTTL.DAILY_RANGE.value,
             publish_key=cache_key,
-        )]
+        )
+        return [state_result, *alert_results]
 
     @tracer.start_as_current_span("dra._get_market_status")
     async def _get_market_status(self) -> Optional[MarketStatus]:
@@ -245,22 +254,29 @@ class DailyRangeAnalyzer(Analyzer):
         return None
 
     @tracer.start_as_current_span("dra._update_session_hod_lod")
-    async def _update_session_hod_lod(self, symbol: str, data: dict):
-        """Update session HOD/LOD for the given symbol.
+    async def _update_session_hod_lod(self, symbol: str, data: dict) -> List[MarketDataAnalyzerResult]:
+        """Update session HOD/LOD for the given symbol and return alert results.
+
+        Alert results are appended only when a new extreme is set AND a prior
+        value existed (first-print suppression). The HOD/LOD dicts are always
+        updated unconditionally.
 
         Args:
             symbol: Ticker symbol.
             data: Quote event dict containing price fields.
+
+        Returns:
+            List of 0–2 alert ``MarketDataAnalyzerResult`` entries.
         """
         session = await self._get_session()
         if session is None:
-            return
+            return []
 
         high = data.get("high") or data.get("h")
         low = data.get("low") or data.get("l")
 
         if high is None or low is None:
-            return
+            return []
 
         if session == "pre_market":
             high_dict, low_dict = self._pre_market_high, self._pre_market_low
@@ -269,13 +285,117 @@ class DailyRangeAnalyzer(Analyzer):
         else:
             high_dict, low_dict = self._after_hours_high, self._after_hours_low
 
-        current_high = high_dict.get(symbol)
-        current_low = low_dict.get(symbol)
+        raw_ts = data.get("t") or data.get("timestamp") or (time.time() * 1000)
+        timestamp = raw_ts / 1000
 
-        if current_high is None or high > current_high:
+        alerts: List[MarketDataAnalyzerResult] = []
+
+        previous_high = high_dict.get(symbol)
+        if previous_high is None or high > previous_high:
+            if previous_high is not None:  # suppress first-print alert
+                alerts.append(self._make_alert(symbol, session, "high", high, previous_high, timestamp))
             high_dict[symbol] = high
-        if current_low is None or low < current_low:
+
+        previous_low = low_dict.get(symbol)
+        if previous_low is None or low < previous_low:
+            if previous_low is not None:  # suppress first-print alert
+                alerts.append(self._make_alert(symbol, session, "low", low, previous_low, timestamp))
             low_dict[symbol] = low
+
+        return alerts
+
+    def _make_alert(
+        self,
+        symbol: str,
+        session: str,
+        direction: str,
+        price: float,
+        previous: float,
+        timestamp: float,
+    ) -> MarketDataAnalyzerResult:
+        """Construct a HOD/LOD alert result.
+
+        Args:
+            symbol: Ticker symbol.
+            session: Current market session (``pre_market``, ``regular``,
+                ``after_hours``).
+            direction: ``'high'`` or ``'low'``.
+            price: New extreme price.
+            previous: Prior extreme price (never None — first-print suppressed).
+            timestamp: UTC epoch seconds (float).
+
+        Returns:
+            A ``MarketDataAnalyzerResult`` routed to the HOD or LOD alert channel.
+        """
+        note = self._compute_note(symbol, session, direction, price)
+        cache_key = (
+            WidgetDataCacheKeys.DAILY_RANGE_HOD_ALERT.value
+            if direction == "high"
+            else WidgetDataCacheKeys.DAILY_RANGE_LOD_ALERT.value
+        )
+        return MarketDataAnalyzerResult(
+            data={
+                "symbol":    symbol,
+                "session":   session,
+                "direction": direction,
+                "price":     price,
+                "previous":  previous,
+                "timestamp": timestamp,
+                "note":      note,
+            },
+            cache_key=cache_key,
+            cache_ttl=WidgetDataCacheTTL.DAILY_RANGE_ALERT.value,
+            cache_list_max=100,
+            publish_key=cache_key,
+        )
+
+    def _compute_note(self, symbol: str, session: str, direction: str, price: float) -> str:
+        """Return a human-readable cross-session breach note, or empty string.
+
+        Checks whether the new extreme breaks a prior session's HOD/LOD and
+        formats a note if so. Price values are formatted as ``$%.2f``.
+
+        Args:
+            symbol: Ticker symbol.
+            session: Current market session.
+            direction: ``'high'`` or ``'low'``.
+            price: New extreme price.
+
+        Returns:
+            Formatted note string, or ``''`` if no cross-session breach.
+        """
+        if session == "pre_market":
+            return ""
+
+        if session == "regular":
+            if direction == "high":
+                pm_high = self._pre_market_high.get(symbol)
+                if pm_high is not None and price > pm_high:
+                    return f"Broke pre-market high of ${pm_high:.2f}"
+            else:
+                pm_low = self._pre_market_low.get(symbol)
+                if pm_low is not None and price < pm_low:
+                    return f"Broke pre-market low of ${pm_low:.2f}"
+            return ""
+
+        if session == "after_hours":
+            if direction == "high":
+                rs_high = self._regular_session_high.get(symbol)
+                if rs_high is not None and price > rs_high:
+                    return f"Broke regular session high of ${rs_high:.2f}"
+                pm_high = self._pre_market_high.get(symbol)
+                if pm_high is not None and price > pm_high:
+                    return f"Broke pre-market high of ${pm_high:.2f}"
+            else:
+                rs_low = self._regular_session_low.get(symbol)
+                if rs_low is not None and price < rs_low:
+                    return f"Broke regular session low of ${rs_low:.2f}"
+                pm_low = self._pre_market_low.get(symbol)
+                if pm_low is not None and price < pm_low:
+                    return f"Broke pre-market low of ${pm_low:.2f}"
+            return ""
+
+        return ""  # fallback for unknown session
 
     @tracer.start_as_current_span("dra._check_day_boundary")
     async def _check_day_boundary(self):

--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -38,6 +38,54 @@ from kuhl_haus.mdp.helpers.observability import get_tracer
 
 tracer = get_tracer(__name__)
 
+# ---------------------------------------------------------------------------
+# Cross-session breach note constants
+# ---------------------------------------------------------------------------
+
+_NOTE_TEMPLATES: dict[str, str] = {
+    "pre_market_high":      "Broke pre-market high of ${:.2f}",
+    "pre_market_low":       "Broke pre-market low of ${:.2f}",
+    "regular_session_high": "Broke regular session high of ${:.2f}",
+    "regular_session_low":  "Broke regular session low of ${:.2f}",
+}
+"""Human-readable note templates keyed by prior-session extreme identifier.
+
+Each value is a format string accepting a single float (the prior-session
+extreme price). Add a new key here when a new breach type is introduced,
+then reference it in ``_NOTE_CHECKS`` and ``_BREACH_CONDITIONS``.
+"""
+
+_NOTE_CHECKS: dict[tuple[str, str], list[str]] = {
+    ("regular",     "high"): ["pre_market_high"],
+    ("regular",     "low"):  ["pre_market_low"],
+    ("after_hours", "high"): ["regular_session_high", "pre_market_high"],
+    ("after_hours", "low"):  ["regular_session_low",  "pre_market_low"],
+}
+"""Ordered list of prior-session extreme keys to check per (session, direction).
+
+The first matching entry in ``_BREACH_CONDITIONS`` wins. Sessions not present
+(e.g. ``pre_market``) return an empty list, producing no note.
+
+Ordering matters for ``after_hours``: regular-session extremes are checked
+before pre-market extremes because they are more proximate and meaningful.
+"""
+
+_BREACH_CONDITIONS: dict[str, tuple[str, object]] = {
+    "pre_market_high":      ("_pre_market_high",      lambda price, v: price > v),
+    "pre_market_low":       ("_pre_market_low",        lambda price, v: price < v),
+    "regular_session_high": ("_regular_session_high",  lambda price, v: price > v),
+    "regular_session_low":  ("_regular_session_low",   lambda price, v: price < v),
+}
+"""Maps each prior-session extreme key to (instance_attr_name, breach_condition).
+
+``instance_attr_name`` is the name of the per-symbol dict on ``DailyRangeAnalyzer``
+that holds the prior extreme. ``breach_condition(price, value)`` returns ``True``
+when the new price exceeds the prior extreme in the relevant direction.
+
+To add a new breach type: add an entry here, a template to ``_NOTE_TEMPLATES``,
+and a reference in the appropriate ``_NOTE_CHECKS`` list.
+"""
+
 
 class DailyRangeAnalyzer(Analyzer):
     """Tracks intraday session highs and lows for real-time quote events.
@@ -352,50 +400,33 @@ class DailyRangeAnalyzer(Analyzer):
     def _compute_note(self, symbol: str, session: str, direction: str, price: float) -> str:
         """Return a human-readable cross-session breach note, or empty string.
 
-        Checks whether the new extreme breaks a prior session's HOD/LOD and
-        formats a note if so. Price values are formatted as ``$%.2f``.
+        Walks ``_NOTE_CHECKS[(session, direction)]`` in priority order and
+        returns the formatted note for the first prior-session extreme that
+        the new price breaches. Returns ``''`` if no breach or if the session
+        has no checks defined (e.g. ``pre_market``).
+
+        Breach logic, note templates, and check order are defined in the
+        module-level constants ``_NOTE_CHECKS``, ``_BREACH_CONDITIONS``, and
+        ``_NOTE_TEMPLATES``. Extend those constants to add new breach types
+        without modifying this method.
 
         Args:
             symbol: Ticker symbol.
-            session: Current market session.
+            session: Current market session (``pre_market``, ``regular``,
+                ``after_hours``).
             direction: ``'high'`` or ``'low'``.
             price: New extreme price.
 
         Returns:
-            Formatted note string, or ``''`` if no cross-session breach.
+            Formatted note string (e.g. ``'Broke pre-market high of $15.00'``),
+            or ``''`` if no cross-session breach applies.
         """
-        if session == "pre_market":
-            return ""
-
-        if session == "regular":
-            if direction == "high":
-                pm_high = self._pre_market_high.get(symbol)
-                if pm_high is not None and price > pm_high:
-                    return f"Broke pre-market high of ${pm_high:.2f}"
-            else:
-                pm_low = self._pre_market_low.get(symbol)
-                if pm_low is not None and price < pm_low:
-                    return f"Broke pre-market low of ${pm_low:.2f}"
-            return ""
-
-        if session == "after_hours":
-            if direction == "high":
-                rs_high = self._regular_session_high.get(symbol)
-                if rs_high is not None and price > rs_high:
-                    return f"Broke regular session high of ${rs_high:.2f}"
-                pm_high = self._pre_market_high.get(symbol)
-                if pm_high is not None and price > pm_high:
-                    return f"Broke pre-market high of ${pm_high:.2f}"
-            else:
-                rs_low = self._regular_session_low.get(symbol)
-                if rs_low is not None and price < rs_low:
-                    return f"Broke regular session low of ${rs_low:.2f}"
-                pm_low = self._pre_market_low.get(symbol)
-                if pm_low is not None and price < pm_low:
-                    return f"Broke pre-market low of ${pm_low:.2f}"
-            return ""
-
-        return ""  # fallback for unknown session
+        for key in _NOTE_CHECKS.get((session, direction), []):
+            attr, condition = _BREACH_CONDITIONS[key]
+            value = getattr(self, attr).get(symbol)
+            if value is not None and condition(price, value):
+                return _NOTE_TEMPLATES[key].format(value)
+        return ""
 
     @tracer.start_as_current_span("dra._check_day_boundary")
     async def _check_day_boundary(self):

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_keys.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_keys.py
@@ -68,3 +68,7 @@ class WidgetDataCacheKeys(Enum):
 
     # Daily range (HOD/LOD) feed
     DAILY_RANGE = 'daily_range'  # Usage: f'{DAILY_RANGE.value}:{symbol}'
+
+    # Daily range alert event channels (shared by all tickers, no symbol suffix)
+    DAILY_RANGE_HOD_ALERT = 'daily_range_hod_alert'
+    DAILY_RANGE_LOD_ALERT = 'daily_range_lod_alert'

--- a/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
+++ b/src/kuhl_haus/mdp/enum/widget_data_cache_ttl.py
@@ -7,6 +7,7 @@ consumption. Separated from MarketDataCacheTTL which governs internal MDC data.
 from enum import Enum
 
 from kuhl_haus.mdp.enum.constants import (
+    EIGHT_HOURS,
     FOUR_DAYS,
     ONE_MINUTE,
     SEVEN_DAYS,
@@ -40,3 +41,6 @@ class WidgetDataCacheTTL(Enum):
 
     # Daily range (HOD/LOD) cache
     DAILY_RANGE = FOUR_DAYS  # 4 days — consistent with QUOTE TTL
+
+    # Daily range alert event channels — 8 hours; alerts are intraday only
+    DAILY_RANGE_ALERT = EIGHT_HOURS

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -679,3 +679,415 @@ async def test_dra_rehydrate_when_market_closed_skips_rehydration(mock_options):
     assert sut._regular_session_high == {}
     assert sut._after_hours_high == {}
     redis.scan.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# HOD/LOD alert emission
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_alert_first_tick_emits_no_alert(sut, mock_rest_client):
+    # Arrange — first tick for symbol, no prior HOD/LOD
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+
+    # Act
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=155.0, low=145.0))
+
+    # Assert — only state result; no alert
+    assert results is not None
+    assert len(results) == 1
+    assert results[0].publish_key == f"{WidgetDataCacheKeys.DAILY_RANGE.value}:AAPL"
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_second_tick_higher_high_emits_hod_alert(sut, mock_rest_client):
+    # Arrange — seed a prior HOD, then send a higher tick
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=156.0, low=146.0))
+
+    # Assert — state + HOD alert
+    assert results is not None
+    assert len(results) == 2
+    alert = results[1]
+    assert alert.publish_key == WidgetDataCacheKeys.DAILY_RANGE_HOD_ALERT.value
+    assert alert.cache_key == WidgetDataCacheKeys.DAILY_RANGE_HOD_ALERT.value
+    assert alert.data["symbol"] == "AAPL"
+    assert alert.data["direction"] == "high"
+    assert alert.data["price"] == 156.0
+    assert alert.data["previous"] == 155.0
+    assert alert.data["session"] == "regular"
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_lower_low_emits_lod_alert(sut, mock_rest_client):
+    # Arrange — seed a prior LOD, then send a lower tick
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=154.0, low=144.0))
+
+    # Assert — state + LOD alert; no HOD alert
+    assert results is not None
+    assert len(results) == 2
+    alert = results[1]
+    assert alert.publish_key == WidgetDataCacheKeys.DAILY_RANGE_LOD_ALERT.value
+    assert alert.data["direction"] == "low"
+    assert alert.data["price"] == 144.0
+    assert alert.data["previous"] == 145.0
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_both_new_hod_and_lod_emits_two_alerts(sut, mock_rest_client):
+    # Arrange — seed prior values, then send tick exceeding both
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act — wider range: new HOD and new LOD simultaneously
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=160.0, low=140.0))
+
+    # Assert — state + two alerts
+    assert results is not None
+    assert len(results) == 3
+    directions = {r.data["direction"] for r in results[1:]}
+    assert directions == {"high", "low"}
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_no_new_extreme_emits_no_alert(sut, mock_rest_client):
+    # Arrange — seed prior values, then send tick within existing range
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act — tick within existing range
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=154.0, low=146.0))
+
+    # Assert — state only
+    assert results is not None
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_hod_cache_key_and_publish_key_are_hod_channel(sut, mock_rest_client):
+    # Arrange
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=156.0, low=146.0))
+
+    # Assert
+    hod_alert = results[1]
+    assert hod_alert.cache_key == WidgetDataCacheKeys.DAILY_RANGE_HOD_ALERT.value
+    assert hod_alert.publish_key == WidgetDataCacheKeys.DAILY_RANGE_HOD_ALERT.value
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_lod_cache_key_and_publish_key_are_lod_channel(sut, mock_rest_client):
+    # Arrange
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=154.0, low=144.0))
+
+    # Assert
+    lod_alert = results[1]
+    assert lod_alert.cache_key == WidgetDataCacheKeys.DAILY_RANGE_LOD_ALERT.value
+    assert lod_alert.publish_key == WidgetDataCacheKeys.DAILY_RANGE_LOD_ALERT.value
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_cache_list_max_is_100(sut, mock_rest_client):
+    # Arrange
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=156.0, low=144.0))
+
+    # Assert — both alert results have cache_list_max=100
+    for alert in results[1:]:
+        assert alert.cache_list_max == 100
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_cache_ttl_is_eight_hours(sut, mock_rest_client):
+    # Arrange
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=156.0, low=144.0))
+
+    # Assert
+    for alert in results[1:]:
+        assert alert.cache_ttl == WidgetDataCacheTTL.DAILY_RANGE_ALERT.value
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_session_field_matches_current_session(sut, mock_rest_client):
+    # Arrange — pre_market session
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="closed", early_hours=True, after_hours=False
+    )
+    sut._pre_market_high["AAPL"] = 155.0
+    sut._pre_market_low["AAPL"] = 145.0
+
+    # Act
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=156.0, low=144.0))
+
+    # Assert — alerts have session="pre_market"
+    for alert in results[1:]:
+        assert alert.data["session"] == "pre_market"
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_after_day_boundary_reset_first_tick_silent(sut, mock_rest_client, mock_redis):
+    # Arrange — simulate day boundary reset, then first tick
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    mock_redis.eval = AsyncMock(return_value=1)  # Lua returns 1 → reset fires
+
+    # Seed values that will be cleared by the reset
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act — reset fires inside analyze_data; dicts cleared; first tick after reset
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=160.0, low=140.0))
+
+    # Assert — no alert (first tick after reset)
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_after_rehydration_matched_value_no_alert(sut, mock_rest_client):
+    # Arrange — simulate rehydrated state, then tick at exact HOD (not exceeded)
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act — tick exactly at stored values
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=155.0, low=145.0))
+
+    # Assert — no alert
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_after_rehydration_exceeded_value_emits_alert(sut, mock_rest_client):
+    # Arrange — simulate rehydrated state, then tick exceeding HOD
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act — tick above stored HOD
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=156.0, low=146.0))
+
+    # Assert — HOD alert emitted
+    assert len(results) == 2
+    assert results[1].data["direction"] == "high"
+
+
+# ------------------------------------------------------------------
+# _compute_note — note field logic
+# ------------------------------------------------------------------
+
+def test_dra_compute_note_pre_market_always_empty(sut):
+    # Arrange
+    sut._pre_market_high["AAPL"] = 155.0
+
+    # Act / Assert
+    assert sut._compute_note("AAPL", "pre_market", "high", 160.0) == ""
+
+
+def test_dra_compute_note_regular_hod_no_breach_is_empty(sut):
+    # Arrange — regular HOD, but below pre-market high
+    sut._pre_market_high["AAPL"] = 165.0
+
+    # Act / Assert
+    assert sut._compute_note("AAPL", "regular", "high", 160.0) == ""
+
+
+def test_dra_compute_note_regular_hod_breaks_pre_market_high(sut):
+    # Arrange
+    sut._pre_market_high["AAPL"] = 155.0
+
+    # Act
+    note = sut._compute_note("AAPL", "regular", "high", 156.0)
+
+    # Assert
+    assert note == "Broke pre-market high of $155.00"
+
+
+def test_dra_compute_note_regular_lod_breaks_pre_market_low(sut):
+    # Arrange
+    sut._pre_market_low["AAPL"] = 145.0
+
+    # Act
+    note = sut._compute_note("AAPL", "regular", "low", 144.0)
+
+    # Assert
+    assert note == "Broke pre-market low of $145.00"
+
+
+def test_dra_compute_note_after_hours_hod_breaks_regular_session_high(sut):
+    # Arrange
+    sut._regular_session_high["AAPL"] = 158.0
+
+    # Act
+    note = sut._compute_note("AAPL", "after_hours", "high", 160.0)
+
+    # Assert
+    assert note == "Broke regular session high of $158.00"
+
+
+def test_dra_compute_note_after_hours_hod_no_regular_high_breaks_pre_market_high(sut):
+    # Arrange — no regular session high set; pre-market high present
+    sut._pre_market_high["AAPL"] = 155.0
+
+    # Act
+    note = sut._compute_note("AAPL", "after_hours", "high", 157.0)
+
+    # Assert
+    assert note == "Broke pre-market high of $155.00"
+
+
+def test_dra_compute_note_after_hours_hod_both_prior_highs_none_is_empty(sut):
+    # Arrange — neither regular nor pre-market high set
+    # Act / Assert
+    assert sut._compute_note("AAPL", "after_hours", "high", 160.0) == ""
+
+
+def test_dra_compute_note_after_hours_hod_no_breach_is_empty(sut):
+    # Arrange — regular session high above new tick
+    sut._regular_session_high["AAPL"] = 165.0
+
+    # Act / Assert
+    assert sut._compute_note("AAPL", "after_hours", "high", 160.0) == ""
+
+
+def test_dra_compute_note_after_hours_lod_breaks_regular_session_low(sut):
+    # Arrange
+    sut._regular_session_low["AAPL"] = 142.0
+
+    # Act
+    note = sut._compute_note("AAPL", "after_hours", "low", 140.0)
+
+    # Assert
+    assert note == "Broke regular session low of $142.00"
+
+
+def test_dra_compute_note_after_hours_lod_both_prior_lows_none_is_empty(sut):
+    # Arrange — neither regular nor pre-market low set
+    # Act / Assert
+    assert sut._compute_note("AAPL", "after_hours", "low", 140.0) == ""
+
+
+def test_dra_compute_note_price_formatted_to_two_decimal_places(sut):
+    # Arrange
+    sut._pre_market_high["AAPL"] = 15.0
+
+    # Act
+    note = sut._compute_note("AAPL", "regular", "high", 16.0)
+
+    # Assert — $15.00 not $15 or $15.0
+    assert note == "Broke pre-market high of $15.00"
+
+
+# ------------------------------------------------------------------
+# Timestamp normalization
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_alert_timestamp_normalized_from_milliseconds(sut, mock_rest_client):
+    # Arrange — tick with "t" field in milliseconds
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+    tick = _make_quote(symbol="AAPL", high=156.0, low=146.0)
+    tick["t"] = 1745364812345  # milliseconds
+
+    # Act
+    results = await sut.analyze_data(tick)
+
+    # Assert — timestamp in seconds
+    assert len(results) == 2
+    assert results[1].data["timestamp"] == pytest.approx(1745364812.345, rel=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_timestamp_falls_back_to_time_time_when_absent(sut, mock_rest_client):
+    # Arrange — tick with no "t" or "timestamp" field
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+    tick = {"symbol": "AAPL", "high": 156.0, "low": 146.0}
+
+    before = time.time()
+    results = await sut.analyze_data(tick)
+    after = time.time()
+
+    # Assert — timestamp within the test window
+    assert len(results) == 2
+    ts = results[1].data["timestamp"]
+    assert before <= ts <= after
+
+
+# ------------------------------------------------------------------
+# State result always first
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_analyze_data_state_result_always_first(sut, mock_rest_client):
+    # Arrange — tick that will produce both alerts
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+
+    # Act
+    results = await sut.analyze_data(_make_quote(symbol="AAPL", high=160.0, low=140.0))
+
+    # Assert — first result is the state result (daily_range:{symbol} key)
+    assert results[0].publish_key == f"{WidgetDataCacheKeys.DAILY_RANGE.value}:AAPL"
+    assert results[0].cache_key == f"{WidgetDataCacheKeys.DAILY_RANGE.value}:AAPL"

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -1091,3 +1091,22 @@ async def test_dra_analyze_data_state_result_always_first(sut, mock_rest_client)
     # Assert — first result is the state result (daily_range:{symbol} key)
     assert results[0].publish_key == f"{WidgetDataCacheKeys.DAILY_RANGE.value}:AAPL"
     assert results[0].cache_key == f"{WidgetDataCacheKeys.DAILY_RANGE.value}:AAPL"
+
+
+def test_dra_compute_note_after_hours_lod_no_regular_low_breaks_pre_market_low(sut):
+    # Arrange — no regular session low set; pre-market low present
+    sut._pre_market_low["AAPL"] = 142.0
+
+    # Act
+    note = sut._compute_note("AAPL", "after_hours", "low", 140.0)
+
+    # Assert
+    assert note == "Broke pre-market low of $142.00"
+
+
+def test_dra_compute_note_regular_lod_no_breach_is_empty(sut):
+    # Arrange — regular LOD, but above pre-market low
+    sut._pre_market_low["AAPL"] = 130.0
+
+    # Act / Assert
+    assert sut._compute_note("AAPL", "regular", "low", 145.0) == ""

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -1110,3 +1110,15 @@ def test_dra_compute_note_regular_lod_no_breach_is_empty(sut):
 
     # Act / Assert
     assert sut._compute_note("AAPL", "regular", "low", 145.0) == ""
+
+
+def test_dra_compute_note_regular_hod_pre_market_high_none_is_empty(sut):
+    # Arrange — no pre-market high set for symbol
+    # Act / Assert
+    assert sut._compute_note("AAPL", "regular", "high", 160.0) == ""
+
+
+def test_dra_compute_note_regular_lod_pre_market_low_none_is_empty(sut):
+    # Arrange — no pre-market low set for symbol
+    # Act / Assert
+    assert sut._compute_note("AAPL", "regular", "low", 140.0) == ""


### PR DESCRIPTION
## Summary

Extends `DailyRangeAnalyzer.analyze_data()` to append HOD/LOD alert events whenever a new session extreme is set. Consumers subscribe to `daily_range_hod_alert` or `daily_range_lod_alert` for a real-time alert stream suitable for a HOD/LOD alert widget.

refs #106

## What Changed

| File | Change |
|---|---|
| `analyzers/daily_range_analyzer.py` | `_update_session_hod_lod` returns alerts; `_make_alert` + `_compute_note` added as private instance methods |
| `enum/widget_data_cache_keys.py` | `DAILY_RANGE_HOD_ALERT`, `DAILY_RANGE_LOD_ALERT` added |
| `enum/widget_data_cache_ttl.py` | `DAILY_RANGE_ALERT = EIGHT_HOURS` added |
| `tests/analyzers/test_daily_range_analyzer.py` | 29 new tests |

## Alert Payload

```json
{
  "symbol": "AAPL",
  "session": "regular",
  "direction": "high",
  "price": 189.45,
  "previous": 188.90,
  "timestamp": 1745364812.345,
  "note": "Broke pre-market high of $15.00"
}
```

## Key Details

- State result always first; alerts appended (0–2 per tick)
- First-print suppressed — no alert on initial HOD/LOD establishment
- `note` empty string when no cross-session breach
- `cache_list_max=100`, TTL=8h — WDC layer owns trim-oldest behavior
- Post-rehydration: matched values silent; only strictly exceeding values alert

## Test Results

58/58 passing (29 new)