### PR TITLE
feat(DailyRangeAnalyzer): embed full quote in HOD/LOD alert payloads

### DIFF
--- a/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
+++ b/src/kuhl_haus/mdp/analyzers/daily_range_analyzer.py
@@ -341,13 +341,13 @@ class DailyRangeAnalyzer(Analyzer):
         previous_high = high_dict.get(symbol)
         if previous_high is None or high > previous_high:
             if previous_high is not None:  # suppress first-print alert
-                alerts.append(self._make_alert(symbol, session, "high", high, previous_high, timestamp))
+                alerts.append(self._make_alert(symbol, session, "high", high, previous_high, timestamp, data))
             high_dict[symbol] = high
 
         previous_low = low_dict.get(symbol)
         if previous_low is None or low < previous_low:
             if previous_low is not None:  # suppress first-print alert
-                alerts.append(self._make_alert(symbol, session, "low", low, previous_low, timestamp))
+                alerts.append(self._make_alert(symbol, session, "low", low, previous_low, timestamp, data))
             low_dict[symbol] = low
 
         return alerts
@@ -360,6 +360,7 @@ class DailyRangeAnalyzer(Analyzer):
         price: float,
         previous: float,
         timestamp: float,
+        quote: dict,
     ) -> MarketDataAnalyzerResult:
         """Construct a HOD/LOD alert result.
 
@@ -371,6 +372,11 @@ class DailyRangeAnalyzer(Analyzer):
             price: New extreme price.
             previous: Prior extreme price (never None — first-print suppressed).
             timestamp: UTC epoch seconds (float).
+            quote: Full quote dict as received by the analyzer. Its fields are
+                spread into the alert payload so clients can filter on arbitrary
+                quote fields without a second lookup. Quote fields win on any
+                key collision. Fields already present in the quote (e.g.
+                ``symbol``) are not duplicated as alert-specific keys.
 
         Returns:
             A ``MarketDataAnalyzerResult`` routed to the HOD or LOD alert channel.
@@ -383,13 +389,13 @@ class DailyRangeAnalyzer(Analyzer):
         )
         return MarketDataAnalyzerResult(
             data={
-                "symbol":    symbol,
                 "session":   session,
                 "direction": direction,
                 "price":     price,
                 "previous":  previous,
                 "timestamp": timestamp,
                 "note":      note,
+                **quote,
             },
             cache_key=cache_key,
             cache_ttl=WidgetDataCacheTTL.DAILY_RANGE_ALERT.value,

--- a/tests/analyzers/test_daily_range_analyzer.py
+++ b/tests/analyzers/test_daily_range_analyzer.py
@@ -1122,3 +1122,178 @@ def test_dra_compute_note_regular_lod_pre_market_low_none_is_empty(sut):
     # Arrange — no pre-market low set for symbol
     # Act / Assert
     assert sut._compute_note("AAPL", "regular", "low", 140.0) == ""
+
+
+# ------------------------------------------------------------------
+# Alert quote fields (flat merge)
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dra_alert_hod_merges_quote_fields_flat(sut, mock_rest_client):
+    # Arrange — seed prior HOD; quote carries extra fields beyond high/low
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+    quote = _make_quote(symbol="AAPL", high=156.0, low=146.0, volume=1000, vwap=155.5)
+
+    # Act
+    results = await sut.analyze_data(quote)
+
+    # Assert — quote fields are present at the top level; no nested 'quote' key
+    alert = next(r for r in results if r.data.get("direction") == "high")
+    assert "quote" not in alert.data
+    assert alert.data["volume"] == 1000
+    assert alert.data["vwap"] == 155.5
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_lod_merges_quote_fields_flat(sut, mock_rest_client):
+    # Arrange — seed prior LOD; quote carries extra fields beyond high/low
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+    quote = _make_quote(symbol="AAPL", high=154.0, low=144.0, volume=500, pct_change=-0.48)
+
+    # Act
+    results = await sut.analyze_data(quote)
+
+    # Assert — quote fields present flat; no nested 'quote' key
+    alert = next(r for r in results if r.data.get("direction") == "low")
+    assert "quote" not in alert.data
+    assert alert.data["volume"] == 500
+    assert alert.data["pct_change"] == pytest.approx(-0.48)
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_quote_fields_win_on_collision(sut, mock_rest_client):
+    # Arrange — quote has 'symbol'; quote value must win over any alert default
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+    quote = _make_quote(symbol="AAPL", high=156.0, low=146.0)
+
+    # Act
+    results = await sut.analyze_data(quote)
+
+    # Assert — symbol comes from quote; alert-only fields are still present
+    alert = next(r for r in results if r.data.get("direction") == "high")
+    assert alert.data["symbol"] == "AAPL"
+    assert alert.data["direction"] == "high"
+    assert alert.data["price"] == 156.0
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_minimal_quote_does_not_raise(sut, mock_rest_client):
+    # Arrange — bare-minimum quote; merge must not raise on missing optional fields
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+    quote = {"symbol": "AAPL", "high": 156.0, "low": 146.0, "close": 150.0,
+             "start_timestamp": 1776973680000}
+
+    # Act
+    results = await sut.analyze_data(quote)
+
+    # Assert — alert is valid; direction and price present
+    alert = next(r for r in results if r.data.get("direction") == "high")
+    assert alert.data["symbol"] == "AAPL"
+    assert alert.data["direction"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_does_not_mutate_input_quote(sut, mock_rest_client):
+    # Arrange
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+    quote = _make_quote(symbol="AAPL", high=156.0, low=146.0, volume=1000)
+    original_keys = set(quote.keys())
+    original_volume = quote["volume"]
+
+    # Act
+    await sut.analyze_data(quote)
+
+    # Assert — original quote dict is unmodified after the call
+    assert set(quote.keys()) == original_keys
+    assert quote["volume"] == original_volume
+    assert "direction" not in quote
+    assert "previous" not in quote
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_both_extremes_produce_independent_dicts(sut, mock_rest_client):
+    # Arrange — tick that fires both HOD and LOD alerts
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAPL"] = 155.0
+    sut._regular_session_low["AAPL"] = 145.0
+    quote = _make_quote(symbol="AAPL", high=160.0, low=140.0)
+
+    # Act
+    results = await sut.analyze_data(quote)
+
+    # Assert — the two alert dicts are independent objects, not shared references
+    assert len(results) == 3
+    hod = next(r for r in results if r.data.get("direction") == "high")
+    lod = next(r for r in results if r.data.get("direction") == "low")
+    assert hod.data is not lod.data
+
+
+@pytest.mark.asyncio
+async def test_dra_alert_flat_payload_includes_all_production_quote_fields(sut, mock_rest_client):
+    # Arrange — production-representative full quote dict
+    mock_rest_client.get_market_status.return_value = MarketStatus(
+        market="open", early_hours=False, after_hours=False
+    )
+    sut._regular_session_high["AAAA"] = 28.80
+    sut._regular_session_low["AAAA"] = 28.87
+    quote = {
+        "symbol": "AAAA",
+        "volume": 175,
+        "free_float": 0,
+        "accumulated_volume": 1403,
+        "relative_volume": 0.3527539070573569,
+        "official_open_price": 28.93,
+        "vwap": 28.8,
+        "open": 28.93,
+        "close": 28.8,
+        "high": 28.93,
+        "low": 28.80,
+        "aggregate_vwap": 28.8988,
+        "average_size": 175,
+        "avg_volume": 3977.2769966,
+        "prev_day_close": 28.9385,
+        "prev_day_open": 28.87,
+        "prev_day_high": 28.9385,
+        "prev_day_low": 28.87,
+        "prev_day_volume": 2434.3257,
+        "prev_day_vwap": 28.8703,
+        "change": -0.1385000000000005,
+        "pct_change": -0.47860117144980047,
+        "change_since_open": -0.129999999999999,
+        "pct_change_since_open": -0.44936052540614935,
+        "start_timestamp": 1776973680000,
+        "end_timestamp": 1776973740000,
+    }
+
+    # Act
+    results = await sut.analyze_data(quote)
+
+    # Assert — all quote fields present flat in the HOD alert
+    alert = next(r for r in results if r.data.get("direction") == "high")
+    assert "quote" not in alert.data
+    assert alert.data["relative_volume"] == pytest.approx(0.3527539070573569)
+    assert alert.data["pct_change"] == pytest.approx(-0.47860117144980047)
+    assert alert.data["accumulated_volume"] == 1403
+    assert alert.data["free_float"] == 0


### PR DESCRIPTION
## Summary

Extends `_make_alert()` to accept the full quote dict and merge its fields flat into the HOD/LOD alert payload. Clients can filter alerts on arbitrary quote fields (price, volume, float, relative volume, etc.) without a second Redis lookup.

Quote fields win on any collision. Fields already present in the quote (e.g. `symbol`) are not duplicated as alert-specific keys — only genuinely alert-only fields (`direction`, `previous`, `session`, `note`, `price`, `timestamp`) are added.

## Changes

- `_make_alert()` gains a `quote: dict` parameter; quote fields are spread flat into the payload (`{...alert_fields, **quote}`), so quote wins on collision
- `symbol` removed from explicit alert fields — it comes from the quote
- Both call sites in `_update_session_hod_lod()` pass the `data` dict (already in scope)
- 7 new tests: flat merge for HOD/LOD, quote-wins collision, minimal quote, no input mutation, independent dicts per extreme, full production field set

## Tests

750 passing (was 743).

refs #110