### PR TITLE
docs: add DailyRangeAnalyzer to analyzers module docs

### DIFF
--- a/docs/mdp/kuhl_haus.mdp.analyzers.rst
+++ b/docs/mdp/kuhl_haus.mdp.analyzers.rst
@@ -17,6 +17,14 @@ kuhl\_haus.mdp.analyzers.analyzer module
    :show-inheritance:
    :undoc-members:
 
+kuhl\_haus.mdp.analyzers.daily\_range\_analyzer module
+------------------------------------------------------
+
+.. automodule:: kuhl_haus.mdp.analyzers.daily_range_analyzer
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 kuhl\_haus.mdp.analyzers.leaderboard\_analyzer module
 -----------------------------------------------------
 


### PR DESCRIPTION
Adds the missing `daily_range_analyzer` module entry to the Sphinx autodoc RST, in alphabetical order between `analyzer` and `leaderboard_analyzer`.