### PR TITLE
docs: add troubleshooting section with v0.4.1 layout recovery guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Contents
    Security Policy <security>
    License <license>
    Authors <authors>
+   Troubleshooting <troubleshooting>
    Changelog <changelog>
 
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,0 +1,9 @@
+.. _troubleshooting:
+
+Troubleshooting
+===============
+
+.. toctree::
+   :maxdepth: 1
+
+   Recovering Layouts After Upgrading to v0.4.1 <troubleshooting/layout-recovery-v041>

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -3,6 +3,8 @@
 Troubleshooting
 ===============
 
+This section covers known issues and step-by-step recovery procedures.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/troubleshooting/layout-recovery-v041.rst
+++ b/docs/troubleshooting/layout-recovery-v041.rst
@@ -208,7 +208,7 @@ a Mac.
 
 - Your iPad running the dashboard in Safari.
 - A Mac with Safari.
-- A **USB cable** (Lightning or USB-C to USB-C depending on your iPad model).
+- A **USB cable** (Lightning to USB-C or USB-C to USB-C, depending on your iPad and Mac model).
   Wi-Fi pairing works in theory, but USB is more reliable.
 
 **Step 1 — Enable Web Inspector on your iPad**

--- a/docs/troubleshooting/layout-recovery-v041.rst
+++ b/docs/troubleshooting/layout-recovery-v041.rst
@@ -214,17 +214,20 @@ See also: `Enabling Developer Features in Safari
 
 1. Connect your iPad to your Mac with the USB cable. Trust the computer if
    prompted on the iPad.
-2. On your iPad, open Safari and navigate to your dashboard. Keep the tab open
-   and active.
-3. On your Mac in Safari: **Develop → your iPad's name → your dashboard tab**.
-4. The full Web Inspector opens on your Mac, targeting the page on your iPad.
+2. On your iPad, open Safari and navigate to your dashboard. **Keep the tab
+   open and active.**
+3. On your Mac in Safari: **Develop** menu → your iPad's name → your
+   dashboard tab.
+4. The full Web Inspector opens on your Mac, pointing at the page running on
+   your iPad.
 
-From here, the procedure is identical to desktop: find ``dashboard-layouts``
-under **Storage → Local Storage**, copy the value, and build the import JSON
-on your Mac. Then either:
+From here, the procedure is identical to desktop:
 
-- Sync the file via iCloud and import from your iPad, or
-- Import directly from the Mac browser if the dashboard is accessible there.
+- Go to **Storage** → **Local Storage** → find ``dashboard-layouts``.
+- Copy the value, build the import JSON on your Mac, then either:
+
+  - AirDrop the file to your iPad and import from there, or
+  - Sync via iCloud and import from there.
 
 
 Technical Appendix

--- a/docs/troubleshooting/layout-recovery-v041.rst
+++ b/docs/troubleshooting/layout-recovery-v041.rst
@@ -5,41 +5,46 @@ Recovering Dashboard Layouts After Upgrading to v0.4.1
 
 The only visible changes from v0.4.0 to v0.4.1 are UI elements to control
 audio alerts on the Range Alerts and News Feed widgets. Under the hood, local
-storage got a complete overhaul. This means breaking changes — all existing
-dashboard settings will be reset on upgrade.
+storage got a complete overhaul. Unfortunately, this means breaking changes,
+but it is better to do it now than later.
 
-There is no automatic migration and no script, but the dashboard has a
-built-in export function that makes recovery straightforward.
+**Here's what breaks:** All your existing dashboard settings will be reset.
+
+There's no automatic migration. There's no script. However, the dashboard has
+a built-in export function.
 
 
 Before Upgrading
 ----------------
 
-If you have not upgraded yet, export your layouts first:
+Before upgrading:
 
 1. Click **📤 Export** in the toolbar.
-2. Save the downloaded ``dashboard-layouts-<timestamp>.json`` file somewhere safe.
+2. Save the downloaded ``dashboard-layouts-<timestamp>.json`` file somewhere.
+
+
+After Upgrading
+---------------
 
 After upgrading, click **📥 Import** and select that file. The exported format
 is exactly the import format — nothing else required.
 
 .. tip::
 
-   Export before every upgrade. The export captures layout configurations,
-   widget positions, column counts, descriptions, and your default layout.
-   It is a one-second operation.
+   Export before any upgrade, full stop. The export is a clean snapshot of
+   everything — layout configurations, widget positions, column counts,
+   descriptions, and your default layout. It's a 1-second operation.
 
 
-If You Already Upgraded
------------------------
+Remediations
+------------
 
-You have two options:
+If you already upgraded and found your layouts are gone, you have two options:
 
-1. **Roll back** to the previous image. The app will read from the old
-   ``dashboard-layouts`` key and you can follow the export procedure above
-   before upgrading again.
-
-2. **Recover manually** using browser DevTools. Full procedure below.
+1. Rollback to the previous image. The application will read from the
+   ``dashboard-layouts`` key and you can follow the export procedure above.
+2. Copy the ``dashboard-layouts`` key using DevTools and create a specially
+   formatted JSON file for importing. (More details provided below.)
 
 
 What Happened
@@ -50,9 +55,9 @@ from plain localStorage keys to a `Pinia <https://pinia.vuejs.org/>`_ store
 managed by ``pinia-plugin-persistedstate``
 (`#278 <https://github.com/kuhl-haus/kuhl-haus-mdp-app/issues/278>`_).
 
-The precise breaking point is commit ``e0c0d7c`` — 12 commits into the v0.4.1
-development cycle. Before that commit, the dashboard read and wrote four
-separate localStorage keys:
+The precise breaking point is commit ``e0c0d7c`` — **12 commits into the
+v0.4.1 development cycle** (``v0.4.1.dev12-e0c0d7c``). Before that commit,
+the dashboard read and wrote four separate localStorage keys:
 
 .. list-table::
    :header-rows: 1
@@ -61,7 +66,7 @@ separate localStorage keys:
    * - Key
      - What it stored
    * - ``dashboard-layouts``
-     - All saved layouts
+     - All saved layouts (the big one)
    * - ``dashboard-default-layout``
      - Name of the default layout
    * - ``dashboard-layout-locked``
@@ -82,26 +87,33 @@ After ``e0c0d7c``, all of that consolidated into a single key:
        ``isLocked``, ``autosaveEnabled``, and additional widget preferences
 
 When you upgrade, the app starts fresh under the new ``widgetSettings`` key.
-**Your layouts are not gone** — they are still sitting in ``dashboard-layouts``
+**Your layouts are not gone** — they're still sitting in ``dashboard-layouts``
 in localStorage exactly as you left them. The app just stopped looking there.
 
 
-Recovery Procedure (Desktop)
------------------------------
+Recovery Procedure
+------------------
 
-**Step 1 — Open DevTools and find the old key**
+The recovery is a two-step process: extract the raw layout data from the old
+key, wrap it in the dashboard's import format, then import it through the UI.
 
-Open the dashboard in your browser, then open DevTools:
+**Step 1 — Open your browser's DevTools and find the old key**
 
-- **Chrome / Edge:** ``F12`` or ``Cmd+Opt+I`` (Mac) / ``Ctrl+Shift+I`` (Windows/Linux)
-- **Firefox:** ``F12`` or ``Ctrl+Shift+I``
+Desktop (Chrome, Firefox, Edge):
 
-Go to the **Application** tab (Chrome/Edge) or **Storage** tab (Firefox).
-In the left sidebar, expand **Local Storage** and click your site's origin
-(e.g. ``https://mdp.example.com`` or ``http://localhost:4201``).
+1. Open the dashboard in your browser.
+2. Open DevTools:
 
-Find the row with Key = ``dashboard-layouts``. The value will be a JSON object
-like this::
+   - Chrome/Edge: ``F12`` or ``Cmd+Opt+I`` (Mac) / ``Ctrl+Shift+I`` (Windows/Linux)
+   - Firefox: ``F12`` or ``Ctrl+Shift+I``
+
+3. Go to the **Application** tab (Chrome/Edge) or **Storage** tab (Firefox).
+4. In the left sidebar, expand **Local Storage** and click your site's origin
+   (e.g. ``https://mdp.example.com`` or ``http://localhost:8000``).
+5. Find the row with Key = ``dashboard-layouts``.
+
+You should see a JSON object in the Value column that looks something like
+this::
 
     {
       "My Trading Setup": {
@@ -115,23 +127,25 @@ like this::
       "Scalp Setup": { ... }
     }
 
-Copy the entire value — everything from the opening ``{`` to the closing ``}``.
+6. **Copy the entire value** — everything including the opening ``{`` and the
+   closing ``}``.
 
 .. note::
 
    If ``dashboard-layouts`` is missing or empty, your layouts were already
-   gone before the upgrade, or you are on a fresh install. There is nothing
-   to recover.
+   gone before the upgrade, or you're on a fresh install. Unfortunately
+   there's nothing to recover.
 
-**Step 2 — Get your default layout name**
+**Step 2 — Pick your default layout name**
 
-While DevTools is still open, look at the ``dashboard-default-layout`` key.
-Copy the exact value — spelling and capitalization must match a key in the
-``dashboard-layouts`` JSON you just copied.
+While you still have DevTools open, take note of the layout name in the
+``dashboard-default-layout`` key. You'll need it in the next step. It must
+match a key in the JSON you just copied — spelling and capitalization must be
+exact.
 
 **Step 3 — Build the import file**
 
-Create a new file called ``layout-recovery.json`` (the filename does not
+Create a new file called ``layout-recovery.json`` (the filename doesn't
 matter). Paste the following, substituting your values:
 
 .. code-block:: json
@@ -166,46 +180,49 @@ matter). Paste the following, substituting your values:
 
 A few things to know about this format:
 
-- ``version`` must be ``1``.
-- ``exported`` is metadata only — the import ignores it. Any number will do.
-- ``defaultLayout`` is optional. If the name does not match a key in
-  ``layouts``, it is silently ignored.
-- The import **merges** into existing layouts. If a name conflicts, you will
-  be prompted to confirm before overwriting.
+- The ``version`` field must be ``1``.
+- The ``exported`` timestamp is metadata only — the import ignores it. Use any
+  number.
+- ``defaultLayout`` is optional; if the name doesn't match a key in
+  ``layouts``, it's silently ignored.
+- The import **merges** into whatever layouts already exist — it won't wipe
+  anything. If a name conflicts, you'll be prompted to confirm overwrite.
 
 **Step 4 — Import through the dashboard UI**
 
 1. Click the **📥 Import** button in the toolbar.
 2. Select your ``layout-recovery.json`` file.
 3. Confirm the overwrite prompt if one appears.
-4. You should see a confirmation: *"Imported N layout(s)"*.
-5. Set your default in the layout dropdown and re-lock.
+4. You should see an alert: *"Imported N layout(s)"*.
+5. Your layouts are back. Set your default in the layout dropdown and re-lock.
 
 
 Recovery on iPad (Safari + iOS)
 --------------------------------
 
-Mobile browsers do not expose a DevTools UI locally. On iOS, you can access
-the full Safari Web Inspector remotely from a Mac over USB.
+Mobile browsers don't expose a DevTools UI, so the procedure above doesn't
+work directly. On iOS, you can access the full Safari DevTools remotely from
+a Mac.
 
 **What you need**
 
 - Your iPad running the dashboard in Safari.
 - A Mac with Safari.
-- A USB cable (Lightning or USB-C depending on your iPad model). Wi-Fi pairing
-  works in theory, but USB is more reliable.
+- A **USB cable** (Lightning or USB-C to USB-C depending on your iPad model).
+  Wi-Fi pairing works in theory, but USB is more reliable.
 
 **Step 1 — Enable Web Inspector on your iPad**
 
-On iPad: **Settings → Safari → Advanced → Web Inspector → ON**.
+On iPad: **Settings** → **Safari** → **Advanced** → toggle **Web Inspector** ON.
 
 See also: `Inspecting iOS with Safari DevTools
 <https://developer.apple.com/documentation/safari-developer-tools/inspecting-ios>`_
 
 **Step 2 — Enable the Develop menu in Safari on your Mac**
 
-On Mac: **Safari → Settings → Advanced → "Show features for web developers"**
-(or "Show Develop menu in menu bar" in older Safari versions).
+On Mac: **Safari** → **Settings** (or Preferences) → **Advanced** tab →
+check **"Show features for web developers"** (or "Show Develop menu in menu
+bar" in older Safari versions).
 
 See also: `Enabling Developer Features in Safari
 <https://developer.apple.com/documentation/safari-developer-tools/enabling-developer-features>`_
@@ -233,9 +250,9 @@ From here, the procedure is identical to desktop:
 Technical Appendix
 ------------------
 
-**New storage structure (v0.4.1+)**
+**The new storage structure (v0.4.1+)**
 
-The ``widgetSettings`` key now stores:
+For reference, the ``widgetSettings`` key now stores:
 
 .. code-block:: json
 
@@ -252,12 +269,11 @@ The ``widgetSettings`` key now stores:
       "alertManagerOpen": false
     }
 
-After recovering, inspect this key in DevTools to confirm ``savedLayouts``
-contains your layouts.
-
 **Identifying the exact version**
 
-Starting with v0.4.0, the version string is shown in the top-right corner of
-the dashboard header (e.g. ``v0.4.1``). Any build at or after
-``v0.4.1.dev12-e0c0d7c`` uses the new storage layout. If no version string is
-visible, the install is older than ``v0.4.0`` and uses the old keys.
+If you're not sure whether your install crossed the breaking point, starting
+with ``v0.4.0`` the version string is shown in the top-right corner of the
+dashboard header (e.g. ``v0.4.1``). Any build at or after
+``v0.4.1.dev12-e0c0d7c`` has the new storage layout. If you do not see a
+version in the top-right corner then you are on a version earlier than
+``v0.4.0``.

--- a/docs/troubleshooting/layout-recovery-v041.rst
+++ b/docs/troubleshooting/layout-recovery-v041.rst
@@ -1,0 +1,216 @@
+.. _troubleshooting-layout-recovery-v041:
+
+Recovering Dashboard Layouts After Upgrading to v0.4.1
+=======================================================
+
+Starting with **v0.4.1**, the Stock Scanner Dashboard moved its layout storage
+from plain localStorage keys to a `Pinia <https://pinia.vuejs.org/>`_ store
+managed by ``pinia-plugin-persistedstate``. The breaking point is commit
+``e0c0d7c`` — 12 commits into the v0.4.1 cycle.
+
+Before that commit, the dashboard read and wrote four separate localStorage keys:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Key
+     - What it stored
+   * - ``dashboard-layouts``
+     - All saved layouts
+   * - ``dashboard-default-layout``
+     - Name of the default layout
+   * - ``dashboard-layout-locked``
+     - Lock state (``"true"`` / ``"false"``)
+   * - ``dashboard-autosave-enabled``
+     - Autosave state (``"true"`` / ``"false"``)
+
+After ``e0c0d7c``, all of that consolidated into a single key:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Key
+     - What it stores
+   * - ``widgetSettings``
+     - A JSON object containing ``savedLayouts``, ``defaultLayoutName``,
+       ``isLocked``, ``autosaveEnabled``, and additional widget preferences
+
+When you upgrade, the app starts fresh under the new ``widgetSettings`` key.
+**Your layouts are not gone** — they're still sitting in ``dashboard-layouts``
+in localStorage exactly as you left them. The app just stopped looking there.
+
+
+Recovery Procedure (Desktop)
+-----------------------------
+
+The recovery is a two-step process: extract the raw layout data from the old
+key, wrap it in the dashboard's import format, then import it through the UI.
+
+**Step 1 — Open DevTools and find the old key**
+
+Open the dashboard in your browser, then open DevTools:
+
+- **Chrome / Edge:** ``F12`` or ``Cmd+Opt+I`` (Mac) / ``Ctrl+Shift+I`` (Windows/Linux)
+- **Firefox:** ``F12`` or ``Ctrl+Shift+I``
+
+Go to the **Application** tab (Chrome/Edge) or **Storage** tab (Firefox).
+In the left sidebar, expand **Local Storage** and click your site's origin
+(e.g. ``https://mdp.kuhl.haus`` or ``http://localhost:4201``).
+
+Find the row with Key = ``dashboard-layouts``. The value will be a JSON object
+like this::
+
+    {
+      "My Trading Setup": {
+        "layout": [...],
+        "widgetCounter": 7,
+        "dashboardColNum": 12,
+        "created": 1746000000000,
+        "modified": 1747000000000,
+        "description": ""
+      },
+      "Scalp Setup": { ... }
+    }
+
+Copy the entire value — everything from the opening ``{`` to the closing ``}``.
+
+.. note::
+
+   If ``dashboard-layouts`` is missing or empty, there is nothing to recover.
+   This indicates a fresh install or that the layouts were lost prior to
+   upgrading.
+
+**Step 2 — Note your default layout name**
+
+While DevTools is still open, note the exact spelling (including capitalization)
+of the layout name you want to set as default. It must match a key in the JSON
+you just copied.
+
+**Step 3 — Build the import file**
+
+Create a file named ``layout-recovery.json`` with the following structure,
+substituting your values:
+
+.. code-block:: json
+
+    {
+      "version": 1,
+      "exported": 1778262561424,
+      "layouts": <PASTE YOUR dashboard-layouts VALUE HERE>,
+      "defaultLayout": "<EXACT NAME OF ONE OF YOUR LAYOUTS>"
+    }
+
+A few things to know about this format:
+
+- ``version`` must be ``1``.
+- ``exported`` is metadata only — the import ignores it. Any number will do.
+- ``defaultLayout`` is optional. If the name doesn't match a key in
+  ``layouts``, it is silently ignored.
+- The import **merges** into existing layouts. If a name conflicts, you will
+  be prompted to confirm before overwriting.
+
+**Step 4 — Import through the dashboard UI**
+
+1. Unlock the layout (click 🔒 in the toolbar — it should change to ✏️).
+2. Click the **📥 Import** button in the toolbar.
+3. Select your ``layout-recovery.json`` file.
+4. Confirm the overwrite prompt if one appears.
+5. You should see a confirmation: *"Imported N layout(s)"*.
+6. Set your default in the layout dropdown and re-lock.
+
+
+Recovery on iPad (Safari + iOS)
+--------------------------------
+
+Mobile Safari does not expose DevTools locally. You can access the full Web
+Inspector remotely from a Mac over USB.
+
+**What you need**
+
+- Your iPad running the dashboard in Safari.
+- A Mac with Safari.
+- A USB cable (Lightning or USB-C depending on your iPad model).
+
+**Step 1 — Enable Web Inspector on your iPad**
+
+On iPad: **Settings → Safari → Advanced → Web Inspector → ON**.
+
+See also: `Inspecting iOS with Safari DevTools
+<https://developer.apple.com/documentation/safari-developer-tools/inspecting-ios>`_
+
+**Step 2 — Enable the Develop menu in Safari on your Mac**
+
+On Mac: **Safari → Settings → Advanced → "Show features for web developers"**
+(or "Show Develop menu in menu bar" in older Safari versions).
+
+See also: `Enabling Developer Features in Safari
+<https://developer.apple.com/documentation/safari-developer-tools/enabling-developer-features>`_
+
+**Step 3 — Connect and inspect**
+
+1. Connect your iPad to your Mac with the USB cable. Trust the computer if
+   prompted on the iPad.
+2. On your iPad, open Safari and navigate to your dashboard. Keep the tab open
+   and active.
+3. On your Mac in Safari: **Develop → your iPad's name → your dashboard tab**.
+4. The full Web Inspector opens on your Mac, targeting the page on your iPad.
+
+From here, the procedure is identical to desktop: find ``dashboard-layouts``
+under **Storage → Local Storage**, copy the value, build the import JSON on
+your Mac, then either AirDrop the file to your iPad and import from there, or
+import directly from the Mac browser if the dashboard is also accessible from
+the Mac.
+
+
+Avoiding This in the Future
+----------------------------
+
+The dashboard has a built-in export function. Before any upgrade:
+
+1. Unlock the layout (🔒 → ✏️).
+2. Click **📤 Export** in the toolbar.
+3. Save the downloaded ``dashboard-layouts-<timestamp>.json`` file.
+
+If something goes wrong after upgrading, click **📥 Import** and select that
+file. The exported format is exactly the import format — no manual JSON
+construction required.
+
+.. tip::
+
+   Export before every upgrade. The export captures layout configurations,
+   widget positions, column counts, descriptions, and your default layout. It
+   is a 10-second operation.
+
+
+Technical Reference
+-------------------
+
+**New storage structure (v0.4.1+)**
+
+The ``widgetSettings`` key now stores:
+
+.. code-block:: json
+
+    {
+      "savedLayouts": {
+        "My Trading Setup": { ... }
+      },
+      "defaultLayoutName": "My Trading Setup",
+      "isLocked": true,
+      "autosaveEnabled": true,
+      "maxArticles": 1000,
+      "hasTickersOnly": false,
+      "defaultAlertSound": "...",
+      "alertManagerOpen": false
+    }
+
+After recovering, inspect this key in DevTools to confirm ``savedLayouts``
+contains your layouts.
+
+**Identifying the exact version**
+
+The version string is shown in the bottom-right corner of the dashboard header
+(e.g. ``v0.4.1``). Any build at or after ``v0.4.1.dev12-e0c0d7c`` uses the
+new storage layout. Any build at ``v0.4.0`` or earlier uses the old keys.

--- a/docs/troubleshooting/layout-recovery-v041.rst
+++ b/docs/troubleshooting/layout-recovery-v041.rst
@@ -194,7 +194,7 @@ A few things to know about this format:
 2. Select your ``layout-recovery.json`` file.
 3. Confirm the overwrite prompt if one appears.
 4. You should see an alert: *"Imported N layout(s)"*.
-5. Your layouts are back. Set your default in the layout dropdown and re-lock.
+5. Your layouts are back.
 
 
 Recovery on iPad (Safari + iOS)

--- a/docs/troubleshooting/layout-recovery-v041.rst
+++ b/docs/troubleshooting/layout-recovery-v041.rst
@@ -98,7 +98,7 @@ Open the dashboard in your browser, then open DevTools:
 
 Go to the **Application** tab (Chrome/Edge) or **Storage** tab (Firefox).
 In the left sidebar, expand **Local Storage** and click your site's origin
-(e.g. ``https://mdp.kuhl.haus`` or ``http://localhost:4201``).
+(e.g. ``https://mdp.example.com`` or ``http://localhost:4201``).
 
 Find the row with Key = ``dashboard-layouts``. The value will be a JSON object
 like this::

--- a/docs/troubleshooting/layout-recovery-v041.rst
+++ b/docs/troubleshooting/layout-recovery-v041.rst
@@ -3,12 +3,56 @@
 Recovering Dashboard Layouts After Upgrading to v0.4.1
 =======================================================
 
+The only visible changes from v0.4.0 to v0.4.1 are UI elements to control
+audio alerts on the Range Alerts and News Feed widgets. Under the hood, local
+storage got a complete overhaul. This means breaking changes — all existing
+dashboard settings will be reset on upgrade.
+
+There is no automatic migration and no script, but the dashboard has a
+built-in export function that makes recovery straightforward.
+
+
+Before Upgrading
+----------------
+
+If you have not upgraded yet, export your layouts first:
+
+1. Click **📤 Export** in the toolbar.
+2. Save the downloaded ``dashboard-layouts-<timestamp>.json`` file somewhere safe.
+
+After upgrading, click **📥 Import** and select that file. The exported format
+is exactly the import format — nothing else required.
+
+.. tip::
+
+   Export before every upgrade. The export captures layout configurations,
+   widget positions, column counts, descriptions, and your default layout.
+   It is a one-second operation.
+
+
+If You Already Upgraded
+-----------------------
+
+You have two options:
+
+1. **Roll back** to the previous image. The app will read from the old
+   ``dashboard-layouts`` key and you can follow the export procedure above
+   before upgrading again.
+
+2. **Recover manually** using browser DevTools. Full procedure below.
+
+
+What Happened
+-------------
+
 Starting with **v0.4.1**, the Stock Scanner Dashboard moved its layout storage
 from plain localStorage keys to a `Pinia <https://pinia.vuejs.org/>`_ store
-managed by ``pinia-plugin-persistedstate``. The breaking point is commit
-``e0c0d7c`` — 12 commits into the v0.4.1 cycle.
+managed by ``pinia-plugin-persistedstate``
+(`#278 <https://github.com/kuhl-haus/kuhl-haus-mdp-app/issues/278>`_).
 
-Before that commit, the dashboard read and wrote four separate localStorage keys:
+The precise breaking point is commit ``e0c0d7c`` — 12 commits into the v0.4.1
+development cycle. Before that commit, the dashboard read and wrote four
+separate localStorage keys:
 
 .. list-table::
    :header-rows: 1
@@ -38,15 +82,12 @@ After ``e0c0d7c``, all of that consolidated into a single key:
        ``isLocked``, ``autosaveEnabled``, and additional widget preferences
 
 When you upgrade, the app starts fresh under the new ``widgetSettings`` key.
-**Your layouts are not gone** — they're still sitting in ``dashboard-layouts``
+**Your layouts are not gone** — they are still sitting in ``dashboard-layouts``
 in localStorage exactly as you left them. The app just stopped looking there.
 
 
 Recovery Procedure (Desktop)
 -----------------------------
-
-The recovery is a two-step process: extract the raw layout data from the old
-key, wrap it in the dashboard's import format, then import it through the UI.
 
 **Step 1 — Open DevTools and find the old key**
 
@@ -78,20 +119,20 @@ Copy the entire value — everything from the opening ``{`` to the closing ``}``
 
 .. note::
 
-   If ``dashboard-layouts`` is missing or empty, there is nothing to recover.
-   This indicates a fresh install or that the layouts were lost prior to
-   upgrading.
+   If ``dashboard-layouts`` is missing or empty, your layouts were already
+   gone before the upgrade, or you are on a fresh install. There is nothing
+   to recover.
 
-**Step 2 — Note your default layout name**
+**Step 2 — Get your default layout name**
 
-While DevTools is still open, note the exact spelling (including capitalization)
-of the layout name you want to set as default. It must match a key in the JSON
-you just copied.
+While DevTools is still open, look at the ``dashboard-default-layout`` key.
+Copy the exact value — spelling and capitalization must match a key in the
+``dashboard-layouts`` JSON you just copied.
 
 **Step 3 — Build the import file**
 
-Create a file named ``layout-recovery.json`` with the following structure,
-substituting your values:
+Create a new file called ``layout-recovery.json`` (the filename does not
+matter). Paste the following, substituting your values:
 
 .. code-block:: json
 
@@ -102,36 +143,57 @@ substituting your values:
       "defaultLayout": "<EXACT NAME OF ONE OF YOUR LAYOUTS>"
     }
 
+**Concrete example:**
+
+.. code-block:: json
+
+    {
+      "version": 1,
+      "exported": 1778262561424,
+      "layouts": {
+        "My Trading Setup": {
+          "layout": [...],
+          "widgetCounter": 7,
+          "dashboardColNum": 12,
+          "created": 1746000000000,
+          "modified": 1747000000000,
+          "description": ""
+        },
+        "Scalp Setup": { ... }
+      },
+      "defaultLayout": "My Trading Setup"
+    }
+
 A few things to know about this format:
 
 - ``version`` must be ``1``.
 - ``exported`` is metadata only — the import ignores it. Any number will do.
-- ``defaultLayout`` is optional. If the name doesn't match a key in
+- ``defaultLayout`` is optional. If the name does not match a key in
   ``layouts``, it is silently ignored.
 - The import **merges** into existing layouts. If a name conflicts, you will
   be prompted to confirm before overwriting.
 
 **Step 4 — Import through the dashboard UI**
 
-1. Unlock the layout (click 🔒 in the toolbar — it should change to ✏️).
-2. Click the **📥 Import** button in the toolbar.
-3. Select your ``layout-recovery.json`` file.
-4. Confirm the overwrite prompt if one appears.
-5. You should see a confirmation: *"Imported N layout(s)"*.
-6. Set your default in the layout dropdown and re-lock.
+1. Click the **📥 Import** button in the toolbar.
+2. Select your ``layout-recovery.json`` file.
+3. Confirm the overwrite prompt if one appears.
+4. You should see a confirmation: *"Imported N layout(s)"*.
+5. Set your default in the layout dropdown and re-lock.
 
 
 Recovery on iPad (Safari + iOS)
 --------------------------------
 
-Mobile Safari does not expose DevTools locally. You can access the full Web
-Inspector remotely from a Mac over USB.
+Mobile browsers do not expose a DevTools UI locally. On iOS, you can access
+the full Safari Web Inspector remotely from a Mac over USB.
 
 **What you need**
 
 - Your iPad running the dashboard in Safari.
 - A Mac with Safari.
-- A USB cable (Lightning or USB-C depending on your iPad model).
+- A USB cable (Lightning or USB-C depending on your iPad model). Wi-Fi pairing
+  works in theory, but USB is more reliable.
 
 **Step 1 — Enable Web Inspector on your iPad**
 
@@ -158,34 +220,15 @@ See also: `Enabling Developer Features in Safari
 4. The full Web Inspector opens on your Mac, targeting the page on your iPad.
 
 From here, the procedure is identical to desktop: find ``dashboard-layouts``
-under **Storage → Local Storage**, copy the value, build the import JSON on
-your Mac, then either AirDrop the file to your iPad and import from there, or
-import directly from the Mac browser if the dashboard is also accessible from
-the Mac.
+under **Storage → Local Storage**, copy the value, and build the import JSON
+on your Mac. Then either:
+
+- Sync the file via iCloud and import from your iPad, or
+- Import directly from the Mac browser if the dashboard is accessible there.
 
 
-Avoiding This in the Future
-----------------------------
-
-The dashboard has a built-in export function. Before any upgrade:
-
-1. Unlock the layout (🔒 → ✏️).
-2. Click **📤 Export** in the toolbar.
-3. Save the downloaded ``dashboard-layouts-<timestamp>.json`` file.
-
-If something goes wrong after upgrading, click **📥 Import** and select that
-file. The exported format is exactly the import format — no manual JSON
-construction required.
-
-.. tip::
-
-   Export before every upgrade. The export captures layout configurations,
-   widget positions, column counts, descriptions, and your default layout. It
-   is a 10-second operation.
-
-
-Technical Reference
--------------------
+Technical Appendix
+------------------
 
 **New storage structure (v0.4.1+)**
 
@@ -211,6 +254,7 @@ contains your layouts.
 
 **Identifying the exact version**
 
-The version string is shown in the bottom-right corner of the dashboard header
-(e.g. ``v0.4.1``). Any build at or after ``v0.4.1.dev12-e0c0d7c`` uses the
-new storage layout. Any build at ``v0.4.0`` or earlier uses the old keys.
+Starting with v0.4.0, the version string is shown in the top-right corner of
+the dashboard header (e.g. ``v0.4.1``). Any build at or after
+``v0.4.1.dev12-e0c0d7c`` uses the new storage layout. If no version string is
+visible, the install is older than ``v0.4.0`` and uses the old keys.


### PR DESCRIPTION
Adds a `troubleshooting/` folder and `troubleshooting.rst` index to the docs.

**First article:** v0.4.1 localStorage → Pinia migration layout recovery — desktop procedure (DevTools + import JSON), iPad/Safari remote inspection via USB, pre-upgrade export recommendation, and a technical appendix covering the new `widgetSettings` structure.

The folder is structured for future articles.