### PR TITLE
docs: note that layout recovery article applies to kuhl-haus-mdp-app

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ kuhl-haus-mdp
 ================
 
 This is the documentation of **kuhl-haus-mdp**. All Kuhl Haus MDP documentation is published
-here because `kuhl-haus-mdp` is the only repository with a Read the Docs Gold subscription.
+here because ``kuhl-haus-mdp`` is the only repository with a Read the Docs Gold subscription.
 I don't like ads. You don't like ads. Nobody wants ads in their documentation so, it all lives
 here. It is, after all, a library package. Enjoy the ad-free experience.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,10 @@
 kuhl-haus-mdp
 ================
 
-This is the documentation of **kuhl-haus-mdp**.
+This is the documentation of **kuhl-haus-mdp**. All Kuhl Haus MDP documentation is published
+here because `kuhl-haus-mdp` is the only repository with a Read the Docs Gold subscription.
+I don't like ads. You don't like ads. Nobody wants ads in their documentation so, it all lives
+here. It is, after all, a library package. Enjoy the ad-free experience.
 
 
 Contents

--- a/docs/troubleshooting/layout-recovery-v041.rst
+++ b/docs/troubleshooting/layout-recovery-v041.rst
@@ -8,8 +8,6 @@ Recovering Dashboard Layouts After Upgrading to v0.4.1
    This article applies to the **front-end application**
    (`kuhl-haus-mdp-app <https://github.com/kuhl-haus/kuhl-haus-mdp-app>`_),
    not the core library (`kuhl-haus-mdp <https://github.com/kuhl-haus/kuhl-haus-mdp>`_).
-   All Kuhl Haus MDP documentation is published here because
-   `kuhl-haus-mdp` is the only repository with a Read the Docs subscription.
 
 The only visible changes from v0.4.0 to v0.4.1 are UI elements to control
 audio alerts on the Range Alerts and News Feed widgets. Under the hood, local

--- a/docs/troubleshooting/layout-recovery-v041.rst
+++ b/docs/troubleshooting/layout-recovery-v041.rst
@@ -3,6 +3,14 @@
 Recovering Dashboard Layouts After Upgrading to v0.4.1
 =======================================================
 
+.. note::
+
+   This article applies to the **front-end application**
+   (`kuhl-haus-mdp-app <https://github.com/kuhl-haus/kuhl-haus-mdp-app>`_),
+   not the core library (`kuhl-haus-mdp <https://github.com/kuhl-haus/kuhl-haus-mdp>`_).
+   All Kuhl Haus MDP documentation is published here because
+   `kuhl-haus-mdp` is the only repository with a Read the Docs subscription.
+
 The only visible changes from v0.4.0 to v0.4.1 are UI elements to control
 audio alerts on the Range Alerts and News Feed widgets. Under the hood, local
 storage got a complete overhaul. Unfortunately, this means breaking changes,


### PR DESCRIPTION
Adds a note at the top of the v0.4.1 layout recovery article clarifying that it applies to the front-end application (`kuhl-haus-mdp-app`), not the core library (`kuhl-haus-mdp`), with an explanation of why the docs live here.