### PR TITLE
docs: add OpenTelemetry configuration section for OTEL-enabled images

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -39,11 +39,25 @@ These variables are supported by all servers.
 OpenTelemetry (OTEL-enabled images)
 ------------------------------------
 
-These variables are only available on ``*-otel`` image variants
-(e.g. ``kuhl-haus-mdl-server:latest-otel``). Standard images do not include
-the OpenTelemetry instrumentation packages and will ignore these variables.
-OTEL-enabled images are published alongside standard images — check the
-package page on GHCR for available tags.
+These variables are only available on ``*-otel-server`` image variants.
+OTEL-enabled images are separate packages from the standard server images —
+the ``-otel`` designation is part of the image name, not the tag.
+
+For example, the OTEL-enabled Market Data Listener is pulled as:
+
+.. code-block:: bash
+
+   docker pull ghcr.io/kuhl-haus/kuhl-haus-mdl-otel-server:latest
+
+or in a Dockerfile:
+
+.. code-block:: dockerfile
+
+   FROM ghcr.io/kuhl-haus/kuhl-haus-mdl-otel-server:latest
+
+All OTEL-enabled images are published in the
+`kuhl-haus-mdp-servers packages <https://github.com/orgs/kuhl-haus/packages?repo_name=kuhl-haus-mdp-servers>`_
+on GHCR.
 
 The variables below are a subset of the standard OpenTelemetry SDK environment
 variables. For the full reference and to understand how OTEL actually works

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -64,9 +64,10 @@ unless noted otherwise.
      - Description
    * - ``OTEL_SERVICE_NAME``
      - *(none)*
-     - Logical service name attached to all traces, metrics, and logs emitted
-       by this instance (e.g. ``mdl``, ``fdl``, ``mds``). Should be unique
-       per server type.
+     - Arbitrary name attached to all traces, metrics, and logs emitted by
+       this instance. The value is your choice — use whatever is meaningful
+       to you. It should be distinct per server type so you can tell services
+       apart in your observability backend.
    * - ``OTEL_TRACES_EXPORTER``
      - *(none)*
      - Exporter for trace data. Options: ``otlp`` — send to an OTLP-compatible

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,9 +69,9 @@ under the hood, see:
 
 .. note::
 
-   None of these variables have defaults. If they are not set, OpenTelemetry
-   is not configured. All variables should be set together — a partial
-   configuration will produce no telemetry output.
+   These images provide no defaults for any of these variables. If they are
+   not set, OpenTelemetry is not configured. All variables should be set
+   together — a partial configuration will produce no telemetry output.
 
 .. list-table::
    :header-rows: 1

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -46,6 +46,12 @@ unless noted otherwise.
 
 .. note::
 
+   None of these variables have defaults. If they are not set, OpenTelemetry
+   is not configured. All variables should be set together — a partial
+   configuration will produce no telemetry output.
+
+.. note::
+
    OTEL-enabled images are published separately from the standard images.
    Check the package page on GHCR for available tags.
 
@@ -57,30 +63,30 @@ unless noted otherwise.
      - Default
      - Description
    * - ``OTEL_SERVICE_NAME``
-     - *(required)*
+     - *(none)*
      - Logical service name attached to all traces, metrics, and logs emitted
        by this instance (e.g. ``mdl``, ``fdl``, ``mds``). Should be unique
        per server type.
    * - ``OTEL_TRACES_EXPORTER``
-     - ``otlp``
+     - *(none)*
      - Exporter for trace data. Options: ``otlp`` — send to an OTLP-compatible
        collector; ``console`` — print to stdout (useful for local debugging);
        ``none`` — disable trace export entirely.
    * - ``OTEL_METRICS_EXPORTER``
-     - ``otlp``
+     - *(none)*
      - Exporter for metrics data. Same options as ``OTEL_TRACES_EXPORTER``:
        ``otlp``, ``console``, or ``none``.
    * - ``OTEL_LOGS_EXPORTER``
-     - ``otlp``
+     - *(none)*
      - Exporter for log data. Same options as ``OTEL_TRACES_EXPORTER``:
        ``otlp``, ``console``, or ``none``.
    * - ``OTEL_EXPORTER_OTLP_PROTOCOL``
-     - ``http/protobuf``
+     - *(none)*
      - Wire protocol used by the OTLP exporter. Options: ``http/protobuf`` —
        HTTP with Protocol Buffers encoding (recommended, most broadly
        supported); ``grpc`` — gRPC; ``http/json`` — HTTP with JSON encoding.
    * - ``OTEL_EXPORTER_OTLP_ENDPOINT``
-     - *(required)*
+     - *(none)*
      - Base URL of the OTLP collector endpoint
        (e.g. ``https://openobserve.example.com/api/default``). The SDK appends
        signal-specific paths (``/v1/traces``, ``/v1/metrics``, ``/v1/logs``)
@@ -91,16 +97,16 @@ unless noted otherwise.
        OTLP export request. Used for authentication and routing
        (e.g. ``Authorization=Bearer <token>,stream-name=default``).
    * - ``OTEL_LOG_LEVEL``
-     - ``error``
+     - *(none)*
      - Internal log level for the OpenTelemetry SDK itself — controls SDK
        diagnostic output, not application log output (see ``LOG_LEVEL`` for
        that). Options: ``debug``, ``info``, ``warning``, ``error``,
        ``critical``.
    * - ``OTEL_PYTHON_FASTAPI_EXCLUDED_URLS``
-     - ``health``
+     - *(none)*
      - Comma-separated URL path patterns excluded from FastAPI auto-
-       instrumentation. The ``health`` endpoint is excluded by default to
-       prevent probe traffic from polluting trace data.
+       instrumentation. Set to ``health`` to prevent probe traffic from
+       polluting trace data.
 
 ----
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -36,6 +36,74 @@ These variables are supported by all servers.
 
 ----
 
+OpenTelemetry (OTEL-enabled images)
+------------------------------------
+
+These variables are only available on image variants built with OpenTelemetry
+instrumentation. They are standard
+`OpenTelemetry SDK environment variables <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/>`_
+unless noted otherwise.
+
+.. note::
+
+   OTEL-enabled images are published separately from the standard images.
+   Check the package page on GHCR for available tags.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 38 20 42
+
+   * - Variable
+     - Default
+     - Description
+   * - ``OTEL_SERVICE_NAME``
+     - *(required)*
+     - Logical service name attached to all traces, metrics, and logs emitted
+       by this instance (e.g. ``mdl``, ``fdl``, ``mds``). Should be unique
+       per server type.
+   * - ``OTEL_TRACES_EXPORTER``
+     - ``otlp``
+     - Exporter for trace data. Options: ``otlp`` — send to an OTLP-compatible
+       collector; ``console`` — print to stdout (useful for local debugging);
+       ``none`` — disable trace export entirely.
+   * - ``OTEL_METRICS_EXPORTER``
+     - ``otlp``
+     - Exporter for metrics data. Same options as ``OTEL_TRACES_EXPORTER``:
+       ``otlp``, ``console``, or ``none``.
+   * - ``OTEL_LOGS_EXPORTER``
+     - ``otlp``
+     - Exporter for log data. Same options as ``OTEL_TRACES_EXPORTER``:
+       ``otlp``, ``console``, or ``none``.
+   * - ``OTEL_EXPORTER_OTLP_PROTOCOL``
+     - ``http/protobuf``
+     - Wire protocol used by the OTLP exporter. Options: ``http/protobuf`` —
+       HTTP with Protocol Buffers encoding (recommended, most broadly
+       supported); ``grpc`` — gRPC; ``http/json`` — HTTP with JSON encoding.
+   * - ``OTEL_EXPORTER_OTLP_ENDPOINT``
+     - *(required)*
+     - Base URL of the OTLP collector endpoint
+       (e.g. ``https://openobserve.example.com/api/default``). The SDK appends
+       signal-specific paths (``/v1/traces``, ``/v1/metrics``, ``/v1/logs``)
+       automatically when using ``http/protobuf`` or ``http/json``.
+   * - ``OTEL_EXPORTER_OTLP_HEADERS``
+     - *(none)*
+     - Comma-separated ``key=value`` pairs sent as HTTP headers with every
+       OTLP export request. Used for authentication and routing
+       (e.g. ``Authorization=Bearer <token>,stream-name=default``).
+   * - ``OTEL_LOG_LEVEL``
+     - ``error``
+     - Internal log level for the OpenTelemetry SDK itself — controls SDK
+       diagnostic output, not application log output (see ``LOG_LEVEL`` for
+       that). Options: ``debug``, ``info``, ``warning``, ``error``,
+       ``critical``.
+   * - ``OTEL_PYTHON_FASTAPI_EXCLUDED_URLS``
+     - ``health``
+     - Comma-separated URL path patterns excluded from FastAPI auto-
+       instrumentation. The ``health`` endpoint is excluded by default to
+       prevent probe traffic from polluting trace data.
+
+----
+
 Finlight Data Listener (FDL)
 -----------------------------
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -39,21 +39,25 @@ These variables are supported by all servers.
 OpenTelemetry (OTEL-enabled images)
 ------------------------------------
 
-These variables are only available on image variants built with OpenTelemetry
-instrumentation. They are standard
-`OpenTelemetry SDK environment variables <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/>`_
-unless noted otherwise.
+These variables are only available on ``*-otel`` image variants
+(e.g. ``kuhl-haus-mdl-server:latest-otel``). Standard images do not include
+the OpenTelemetry instrumentation packages and will ignore these variables.
+OTEL-enabled images are published alongside standard images — check the
+package page on GHCR for available tags.
+
+The variables below are a subset of the standard OpenTelemetry SDK environment
+variables. For the full reference and to understand how OTEL actually works
+under the hood, see:
+
+- `Zero-code instrumentation for Python <https://opentelemetry.io/docs/zero-code/python/configuration/>`_
+- `SDK general configuration <https://opentelemetry.io/docs/languages/sdk-configuration/general/>`_
+- `OTLP exporter configuration <https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/>`_
 
 .. note::
 
    None of these variables have defaults. If they are not set, OpenTelemetry
    is not configured. All variables should be set together — a partial
    configuration will produce no telemetry output.
-
-.. note::
-
-   OTEL-enabled images are published separately from the standard images.
-   Check the package page on GHCR for available tags.
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
Adds an **OpenTelemetry (OTEL-enabled images)** section to the configuration reference, positioned after Common Variables as a cross-cutting concern.

## Variables documented

| Variable | Default |
|---|---|
| `OTEL_SERVICE_NAME` | *(required)* |
| `OTEL_TRACES_EXPORTER` | `otlp` |
| `OTEL_METRICS_EXPORTER` | `otlp` |
| `OTEL_LOGS_EXPORTER` | `otlp` |
| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` |
| `OTEL_EXPORTER_OTLP_ENDPOINT` | *(required)* |
| `OTEL_EXPORTER_OTLP_HEADERS` | *(none)* |
| `OTEL_LOG_LEVEL` | `error` |
| `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS` | `health` |

All three `OTEL_*_EXPORTER` variables document the full option set: `otlp`, `console`, `none`. `OTEL_EXPORTER_OTLP_PROTOCOL` documents all three wire protocol options: `http/protobuf`, `grpc`, `http/json`. `OTEL_LOG_LEVEL` is clearly distinguished from `LOG_LEVEL` (application vs. SDK diagnostic output).